### PR TITLE
Metrics

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,9 @@ on:
       edge_tag:
         description: "Docker tag to use when manually pushing (defaults to edge or branch-based)"
         required: false
+      target_ref:
+        description: "Branch or tag to check out when running manually (defaults to default branch)"
+        required: false
 
 jobs:
   test:
@@ -29,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_ref != '' && github.event.inputs.target_ref || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -59,6 +64,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_ref != '' && github.event.inputs.target_ref || github.ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,15 @@ on:
   pull_request:
     branches:
       - main      
+  workflow_dispatch:
+    inputs:
+      push_to_docker:
+        description: "Build and push Docker images as part of this run"
+        required: false
+        default: "true"
+      edge_tag:
+        description: "Docker tag to use when manually pushing (defaults to edge or branch-based)"
+        required: false
 
 jobs:
   test:
@@ -39,8 +48,8 @@ jobs:
 
   
   build:
-    # Only build/push for main (edge builds)
-    if: github.ref == 'refs/heads/main'
+    # Only build/push automatically for main, or manually when requested
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_docker == 'true')
     needs: test
     runs-on: ubuntu-latest
 
@@ -64,8 +73,19 @@ jobs:
         id: vars
         run: |
           SHORT_SHA=${GITHUB_SHA::7}
-          echo "edge_tag=edge" >> $GITHUB_OUTPUT
-          echo "sha_tag=main-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          EDGE_TAG_INPUT="${{ github.event.inputs.edge_tag }}"
+          if [ -z "$EDGE_TAG_INPUT" ]; then
+            if [ "${{ github.ref == 'refs/heads/main' }}" = "true" ]; then
+              EDGE_TAG="edge"
+            else
+              EDGE_TAG="edge-$(echo "${GITHUB_REF_NAME}" | tr '/' '-')"
+            fi
+          else
+            EDGE_TAG="$EDGE_TAG_INPUT"
+          fi
+          BRANCH_SAFE=$(echo "${GITHUB_REF_NAME}" | tr '/' '-')
+          echo "edge_tag=${EDGE_TAG}" >> $GITHUB_OUTPUT
+          echo "sha_tag=${BRANCH_SAFE}-${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Build and push (main)
         uses: docker/build-push-action@v6

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ beautifulsoup4
 requests
 backoff
 pytest
-
+prometheus-client

--- a/src/ish/metrics.py
+++ b/src/ish/metrics.py
@@ -103,7 +103,7 @@ def start_metrics_server_if_configured() -> None:
     global _METRICS_SERVER_STARTED
     if _METRICS_SERVER_STARTED or start_http_server is None:
         return
-    port_raw = os.environ.get(METRICS_PORT_ENV)
+    port_raw = os.environ.get(METRICS_PORT_ENV, "9100")
     if not port_raw:
         return
     try:

--- a/src/ish/metrics.py
+++ b/src/ish/metrics.py
@@ -1,0 +1,153 @@
+import logging
+import os
+from typing import Any, Dict, Optional
+
+try:
+    from prometheus_client import Counter, Gauge, start_http_server
+except ImportError:  # pragma: no cover
+    Counter = None
+    Gauge = None
+    start_http_server = None
+
+LOG_FORMAT = "%(asctime)s %(levelname)s %(module)s %(message)s"
+DEFAULT_LOG_LEVEL = logging.INFO
+LOG_LEVEL_ENV = "ISH_LOG_LEVEL"
+LOG_LEVELS_ENV = "ISH_LOG_LEVELS"
+METRICS_PORT_ENV = "ISH_METRICS_PORT"
+METRICS_ADDR_ENV = "ISH_METRICS_ADDR"
+_METRICS_SERVER_STARTED = False
+
+MESSAGES_MOVED_COUNTER = (
+    Counter("ish_messages_moved_total", "Total number of messages moved") if Counter else None
+)
+MESSAGES_SKIPPED_COUNTER = (
+    Counter("ish_messages_skipped_total", "Total number of messages skipped") if Counter else None
+)
+TRAINING_EMBEDDINGS_GAUGE = (
+    Gauge("ish_training_embeddings_total", "Embeddings used during last training run") if Gauge else None
+)
+TRAINING_ACCURACY_GAUGE = (
+    Gauge("ish_training_accuracy", "Classifier accuracy from last training run") if Gauge else None
+)
+TRAINING_DURATION_GAUGE = (
+    Gauge("ish_training_duration_seconds", "Seconds spent training the classifier") if Gauge else None
+)
+TRAINING_CLASSIFICATION_GAUGE = (
+    Gauge(
+        "ish_training_classification_metric",
+        "Classification metrics per label and metric",
+        labelnames=("label", "metric"),
+    )
+    if Gauge
+    else None
+)
+
+
+def configure_logging(level: int = DEFAULT_LOG_LEVEL) -> None:
+    """Configure root logging once and honor env overrides."""
+    root_logger = logging.getLogger()
+    formatter = logging.Formatter(LOG_FORMAT)
+    if root_logger.handlers:
+        root_logger.setLevel(level)
+        for handler in root_logger.handlers:
+            handler.setLevel(level)
+            handler.setFormatter(formatter)
+    else:
+        logging.basicConfig(level=level, format=LOG_FORMAT)
+        root_logger = logging.getLogger()
+    _apply_env_logging_overrides(root_logger, formatter)
+
+
+def _apply_env_logging_overrides(root_logger: logging.Logger, formatter: logging.Formatter) -> None:
+    env_level = _parse_log_level(os.environ.get(LOG_LEVEL_ENV))
+    if env_level is not None:
+        root_logger.setLevel(env_level)
+        for handler in root_logger.handlers:
+            handler.setLevel(env_level)
+            handler.setFormatter(formatter)
+
+    for logger_name, level in _parse_named_log_levels(os.environ.get(LOG_LEVELS_ENV)).items():
+        if not logger_name:
+            continue
+        logging.getLogger(logger_name).setLevel(level)
+
+
+def _parse_log_level(raw: Optional[str]) -> Optional[int]:
+    if raw is None:
+        return None
+    value = raw.strip()
+    if not value:
+        return None
+    if value.isdigit():
+        return int(value)
+    name = value.upper()
+    return logging._nameToLevel.get(name)  # type: ignore[attr-defined]
+
+
+def _parse_named_log_levels(raw: Optional[str]) -> Dict[str, int]:
+    overrides: Dict[str, int] = {}
+    if not raw:
+        return overrides
+    for item in raw.split(","):
+        if not item.strip() or "=" not in item:
+            continue
+        name, level_str = item.split("=", 1)
+        parsed = _parse_log_level(level_str)
+        if parsed is not None:
+            overrides[name.strip()] = parsed
+    return overrides
+
+
+def start_metrics_server_if_configured() -> None:
+    """Start Prometheus metrics exporter if configured via env vars."""
+    global _METRICS_SERVER_STARTED
+    if _METRICS_SERVER_STARTED or start_http_server is None:
+        return
+    port_raw = os.environ.get(METRICS_PORT_ENV)
+    if not port_raw:
+        return
+    try:
+        port = int(port_raw)
+    except ValueError:
+        logging.getLogger("ish").warning("Invalid metrics port provided: %s", port_raw)
+        return
+    addr = os.environ.get(METRICS_ADDR_ENV, "0.0.0.0")
+    try:
+        start_http_server(port, addr=addr)
+        _METRICS_SERVER_STARTED = True
+        logging.getLogger("ish").info("Prometheus metrics listening on %s:%s", addr, port)
+    except OSError as exc:
+        logging.getLogger("ish").error("Failed to start metrics server on %s:%s: %s", addr, port, exc)
+
+
+def increment_moved(count: int) -> None:
+    if count <= 0 or MESSAGES_MOVED_COUNTER is None:
+        return
+    MESSAGES_MOVED_COUNTER.inc(count)
+
+
+def increment_skipped(count: int = 1) -> None:
+    if count <= 0 or MESSAGES_SKIPPED_COUNTER is None:
+        return
+    MESSAGES_SKIPPED_COUNTER.inc(count)
+
+
+def record_training_stats(embeddings: int, accuracy: float, duration: float) -> None:
+    if TRAINING_EMBEDDINGS_GAUGE is not None:
+        TRAINING_EMBEDDINGS_GAUGE.set(embeddings)
+    if TRAINING_ACCURACY_GAUGE is not None:
+        TRAINING_ACCURACY_GAUGE.set(accuracy)
+    if TRAINING_DURATION_GAUGE is not None:
+        TRAINING_DURATION_GAUGE.set(duration)
+
+
+def record_classification_metrics(report: Dict[str, Any]) -> None:
+    if TRAINING_CLASSIFICATION_GAUGE is None:
+        return
+    for label, metrics in report.items():
+        if isinstance(metrics, dict):
+            for metric_name, value in metrics.items():
+                TRAINING_CLASSIFICATION_GAUGE.labels(str(label), metric_name).set(value)
+        else:
+            TRAINING_CLASSIFICATION_GAUGE.labels(str(label), "score").set(metrics)
+

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,170 @@
+import logging
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from ish import metrics
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics_state(monkeypatch):
+    # ensure we don't carry over logging handlers or env between tests
+    monkeypatch.setattr(metrics, "_METRICS_SERVER_STARTED", False)
+    yield
+    monkeypatch.undo()
+
+
+def test_configure_logging_basicconfig_called_without_handlers(monkeypatch):
+    root = logging.getLogger()
+    prev_handlers = root.handlers[:]
+    prev_level = root.level
+    for handler in prev_handlers:
+        root.removeHandler(handler)
+
+    called = {}
+
+    def fake_basic_config(*, level, format):
+        called["level"] = level
+        called["format"] = format
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+
+    try:
+        metrics.configure_logging()
+    finally:
+        for handler in root.handlers[:]:
+            root.removeHandler(handler)
+        for handler in prev_handlers:
+            root.addHandler(handler)
+        root.setLevel(prev_level)
+
+    assert called["level"] == metrics.DEFAULT_LOG_LEVEL
+    assert called["format"] == metrics.LOG_FORMAT
+
+
+def test_configure_logging_updates_existing_handlers(monkeypatch):
+    root = logging.getLogger()
+    prev_handlers = root.handlers[:]
+    prev_level = root.level
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.setLevel(logging.WARNING)
+    root.addHandler(handler)
+    root.setLevel(logging.WARNING)
+
+    try:
+        metrics.configure_logging()
+        assert handler.level == metrics.DEFAULT_LOG_LEVEL
+        assert handler.formatter._style._fmt == metrics.LOG_FORMAT
+        assert root.level == metrics.DEFAULT_LOG_LEVEL
+    finally:
+        root.removeHandler(handler)
+        for original in prev_handlers:
+            root.addHandler(original)
+        root.setLevel(prev_level)
+
+
+def test_env_log_level_overrides_root_and_handlers(monkeypatch):
+    root = logging.getLogger()
+    prev_handlers = root.handlers[:]
+    prev_level = root.level
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)
+    monkeypatch.setenv(metrics.LOG_LEVEL_ENV, "DEBUG")
+
+    try:
+        metrics.configure_logging()
+        assert root.level == logging.DEBUG
+        assert handler.level == logging.DEBUG
+    finally:
+        monkeypatch.delenv(metrics.LOG_LEVEL_ENV, raising=False)
+        root.removeHandler(handler)
+        for original in prev_handlers:
+            root.addHandler(original)
+        root.setLevel(prev_level)
+
+
+def test_env_named_log_levels_override_specific_loggers(monkeypatch):
+    target_a = logging.getLogger("ISH")
+    target_b = logging.getLogger("ish.imap")
+    prev_a = target_a.level
+    prev_b = target_b.level
+    monkeypatch.setenv(metrics.LOG_LEVELS_ENV, "ISH=DEBUG,ish.imap=WARNING,invalid")
+
+    try:
+        metrics.configure_logging()
+        assert target_a.level == logging.DEBUG
+        assert target_b.level == logging.WARNING
+    finally:
+        monkeypatch.delenv(metrics.LOG_LEVELS_ENV, raising=False)
+        target_a.setLevel(prev_a)
+        target_b.setLevel(prev_b)
+
+
+def test_metrics_server_starts_when_env_set(monkeypatch):
+    fake_start = mock.MagicMock()
+    monkeypatch.setattr(metrics, "start_http_server", fake_start)
+    monkeypatch.setenv("ISH_METRICS_PORT", "9410")
+    monkeypatch.setenv("ISH_METRICS_ADDR", "127.0.0.1")
+
+    metrics.start_metrics_server_if_configured()
+
+    fake_start.assert_called_once_with(9410, addr="127.0.0.1")
+    assert metrics._METRICS_SERVER_STARTED is True
+
+    monkeypatch.delenv("ISH_METRICS_PORT", raising=False)
+    monkeypatch.delenv("ISH_METRICS_ADDR", raising=False)
+
+
+def test_metrics_server_invalid_port(monkeypatch):
+    fake_start = mock.MagicMock()
+    monkeypatch.setattr(metrics, "start_http_server", fake_start)
+    monkeypatch.setenv("ISH_METRICS_PORT", "not-a-port")
+
+    metrics.start_metrics_server_if_configured()
+
+    fake_start.assert_not_called()
+    assert metrics._METRICS_SERVER_STARTED is False
+
+    monkeypatch.delenv("ISH_METRICS_PORT", raising=False)
+
+
+def test_record_training_stats_updates_gauges(monkeypatch):
+    gauge_embeddings = mock.MagicMock()
+    gauge_accuracy = mock.MagicMock()
+    gauge_duration = mock.MagicMock()
+    monkeypatch.setattr(metrics, "TRAINING_EMBEDDINGS_GAUGE", gauge_embeddings)
+    monkeypatch.setattr(metrics, "TRAINING_ACCURACY_GAUGE", gauge_accuracy)
+    monkeypatch.setattr(metrics, "TRAINING_DURATION_GAUGE", gauge_duration)
+
+    metrics.record_training_stats(10, 0.9, 5.5)
+
+    gauge_embeddings.set.assert_called_once_with(10)
+    gauge_accuracy.set.assert_called_once_with(0.9)
+    gauge_duration.set.assert_called_once_with(5.5)
+
+
+def test_record_classification_metrics(monkeypatch):
+    gauge = mock.MagicMock()
+    labels_mock = mock.MagicMock()
+    gauge.labels.return_value = labels_mock
+    monkeypatch.setattr(metrics, "TRAINING_CLASSIFICATION_GAUGE", gauge)
+
+    report = {
+        "label1": {"precision": 0.5, "recall": 0.7},
+        "accuracy": 0.8,
+    }
+    metrics.record_classification_metrics(report)
+
+    gauge.labels.assert_any_call("label1", "precision")
+    gauge.labels.assert_any_call("label1", "recall")
+    labels_mock.set.assert_called()


### PR DESCRIPTION
This commit isolates metrics-related test cases by moving them from `test_ish.py` to a newly created `test_metrics.py`. This improves modularity and maintainability of the test suite. The migrated tests include those for logging configurations, environment-specific server startup behaviors, training statistics, and classification metrics recording. Additionally, unused imports and monkeypatching related to removed tests were cleaned up in `test_ish.py` to streamline its focus on ISH functionality tests.