### PR TITLE
Fix configurable move-decision thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ ignore_folders:
 - Junk
 openai_api_key: ll-ddjg-RI51oFV-0Du9Xo4ERraVFd0UvcwFPP0wUkTB2tC
 openai_model: text-embedding-3-small
+classification_probability_threshold: 0.55
+classification_runner_up_gap_threshold: 0.15
 ```
+
+`classification_probability_threshold` sets the minimum confidence required before a message is eligible to move.
+`classification_runner_up_gap_threshold` sets the minimum gap between the best and second-best class before a move is considered unambiguous.
 
 ## Running
 

--- a/src/ish/app.py
+++ b/src/ish/app.py
@@ -122,7 +122,9 @@ class ISH:
             max_source_messages=MAX_SOURCE_MESSAGES,
             interactive=self._interactive,
             dry_run=self._dry_run,
-            exit_event=self._exit_event
+            exit_event=self._exit_event,
+            probability_threshold=self.__settings.classification_probability_threshold,
+            runner_up_gap_threshold=self.__settings.classification_runner_up_gap_threshold,
         )
 
         self.moved = 0

--- a/src/ish/classification_service.py
+++ b/src/ish/classification_service.py
@@ -15,6 +15,9 @@ from .message import Message
 
 Action = Enum("Action", ["YES", "NO", "QUIT"])
 
+DEFAULT_PROBABILITY_THRESHOLD = 0.55
+DEFAULT_RUNNER_UP_GAP_THRESHOLD = 0.15
+
 
 class ClassificationService:
     """Handle classification and message moving workflow."""
@@ -31,7 +34,8 @@ class ClassificationService:
         dry_run: bool,
         exit_event: Event,
         logger: Optional[logging.Logger] = None,
-        probability_threshold: float = 0.25,
+        probability_threshold: float = DEFAULT_PROBABILITY_THRESHOLD,
+        runner_up_gap_threshold: float = DEFAULT_RUNNER_UP_GAP_THRESHOLD,
     ) -> None:
         self._imap_conn_provider = imap_conn_provider
         self._get_embeddings = get_embeddings
@@ -42,6 +46,7 @@ class ClassificationService:
         self._dry_run = dry_run
         self._exit_event = exit_event
         self._probability_threshold = probability_threshold
+        self._runner_up_gap_threshold = runner_up_gap_threshold
         self._logger = logger or logging.getLogger("ish").getChild(self.__class__.__name__)
 
         self._classifier: Optional[RandomForestClassifier] = None
@@ -90,15 +95,23 @@ class ClassificationService:
                 proba = classifier.predict_proba([embedding])[0]
                 ranks = sorted(zip(proba, classifier.classes_), reverse=True)
                 top_probability, _ = ranks[0]
+                runner_up_probability = ranks[1][0] if len(ranks) > 1 else 0.0
+                confidence_gap = top_probability - runner_up_probability
                 message_entry = {
                     "uid": uid,
                     "probability": top_probability,
+                    "runner_up_probability": runner_up_probability,
+                    "confidence_gap": confidence_gap,
                     "from": message.from_addr,
                     "body": message.preview(100),
                 }
 
                 if top_probability <= self._probability_threshold:
                     self._log_move(uid, "Skipping due to probability", ranks, message_entry)
+                    self._increment_skipped()
+                    continue
+                if confidence_gap < self._runner_up_gap_threshold:
+                    self._log_move(uid, "Skipping due to ambiguous top prediction", ranks, message_entry)
                     self._increment_skipped()
                     continue
 

--- a/src/ish/classification_service.py
+++ b/src/ish/classification_service.py
@@ -11,13 +11,13 @@ from sklearn.ensemble import RandomForestClassifier
 from . import metrics
 from .imap import ImapHandler
 from .message import Message
+from .settings import (
+    DEFAULT_CLASSIFICATION_PROBABILITY_THRESHOLD,
+    DEFAULT_CLASSIFICATION_RUNNER_UP_GAP_THRESHOLD,
+)
 
 
 Action = Enum("Action", ["YES", "NO", "QUIT"])
-
-DEFAULT_PROBABILITY_THRESHOLD = 0.55
-DEFAULT_RUNNER_UP_GAP_THRESHOLD = 0.15
-
 
 class ClassificationService:
     """Handle classification and message moving workflow."""
@@ -34,8 +34,8 @@ class ClassificationService:
         dry_run: bool,
         exit_event: Event,
         logger: Optional[logging.Logger] = None,
-        probability_threshold: float = DEFAULT_PROBABILITY_THRESHOLD,
-        runner_up_gap_threshold: float = DEFAULT_RUNNER_UP_GAP_THRESHOLD,
+        probability_threshold: float = DEFAULT_CLASSIFICATION_PROBABILITY_THRESHOLD,
+        runner_up_gap_threshold: float = DEFAULT_CLASSIFICATION_RUNNER_UP_GAP_THRESHOLD,
     ) -> None:
         self._imap_conn_provider = imap_conn_provider
         self._get_embeddings = get_embeddings
@@ -91,12 +91,12 @@ class ClassificationService:
                 if message is None:
                     continue
 
-                dest_folder = classifier.predict([embedding])[0]
                 proba = classifier.predict_proba([embedding])[0]
                 ranks = sorted(zip(proba, classifier.classes_), reverse=True)
-                top_probability, _ = ranks[0]
-                runner_up_probability = ranks[1][0] if len(ranks) > 1 else 0.0
-                confidence_gap = top_probability - runner_up_probability
+                dest_folder = str(ranks[0][1])
+                should_move, skip_reason, top_probability, runner_up_probability, confidence_gap = (
+                    self._decision_from_ranks(ranks)
+                )
                 message_entry = {
                     "uid": uid,
                     "probability": top_probability,
@@ -106,12 +106,8 @@ class ClassificationService:
                     "body": message.preview(100),
                 }
 
-                if top_probability <= self._probability_threshold:
-                    self._log_move(uid, "Skipping due to probability", ranks, message_entry)
-                    self._increment_skipped()
-                    continue
-                if confidence_gap < self._runner_up_gap_threshold:
-                    self._log_move(uid, "Skipping due to ambiguous top prediction", ranks, message_entry)
+                if not should_move:
+                    self._log_move(uid, skip_reason, ranks, message_entry)
                     self._increment_skipped()
                     continue
 
@@ -124,7 +120,6 @@ class ClassificationService:
                     if action == Action.QUIT:
                         self._logger.info("User requested quit; stopping classification.")
                         self._exit_event.set()
-                        stop_processing = True
                         break
 
                 to_move.setdefault(dest_folder, []).append(message_entry)
@@ -186,6 +181,38 @@ class ClassificationService:
     def _increment_skipped(self, amount: int = 1) -> None:
         self.skipped += amount
         metrics.increment_skipped(amount)
+
+    def _decision_from_ranks(self, ranks) -> tuple[bool, str, float, float, float]:
+        top_probability, _ = ranks[0]
+        runner_up_probability = ranks[1][0] if len(ranks) > 1 else 0.0
+        confidence_gap = top_probability - runner_up_probability
+
+        if top_probability <= self._probability_threshold:
+            return (
+                False,
+                (
+                    "Skipping due to low confidence "
+                    f"(top={top_probability:.2f}, min={self._probability_threshold:.2f})"
+                ),
+                top_probability,
+                runner_up_probability,
+                confidence_gap,
+            )
+
+        if confidence_gap < self._runner_up_gap_threshold:
+            return (
+                False,
+                (
+                    "Skipping due to ambiguous top prediction "
+                    f"(top={top_probability:.2f}, runner_up={runner_up_probability:.2f}, "
+                    f"gap={confidence_gap:.2f}, min_gap={self._runner_up_gap_threshold:.2f})"
+                ),
+                top_probability,
+                runner_up_probability,
+                confidence_gap,
+            )
+
+        return (True, "Going to move", top_probability, runner_up_probability, confidence_gap)
 
     def _log_move(self, uid: int, text: str, ranks, message_entry) -> None:
         self._logger.debug(

--- a/src/ish/settings.py
+++ b/src/ish/settings.py
@@ -5,6 +5,9 @@ from os.path import exists, isdir
 
 import yaml
 
+DEFAULT_CLASSIFICATION_PROBABILITY_THRESHOLD = 0.55
+DEFAULT_CLASSIFICATION_RUNNER_UP_GAP_THRESHOLD = 0.15
+
 
 class Settings(dict):
     """Settings for the application"""
@@ -69,6 +72,14 @@ class Settings(dict):
     def openai_model(self) -> str:
         return self["openai_model"]
 
+    @property
+    def classification_probability_threshold(self) -> float:
+        return float(self["classification_probability_threshold"])
+
+    @property
+    def classification_runner_up_gap_threshold(self) -> float:
+        return float(self["classification_runner_up_gap_threshold"])
+
     def __set_directories(self):
         if self["data_directory"] == "":
             self["data_directory"] = os.path.join(self.config_directory, "data")
@@ -106,6 +117,8 @@ class Settings(dict):
         self["data_directory"] = ""
         self["openai_api_key"] = ""
         self["openai_model"] = "text-embedding-ada-002"
+        self["classification_probability_threshold"] = DEFAULT_CLASSIFICATION_PROBABILITY_THRESHOLD
+        self["classification_runner_up_gap_threshold"] = DEFAULT_CLASSIFICATION_RUNNER_UP_GAP_THRESHOLD
 
         self.config_directory = os.environ.get("ISH_CONFIG_PATH")
         if self.config_directory is None or self.config_directory == "":
@@ -114,8 +127,28 @@ class Settings(dict):
 
         if exists(self.settings_file):
             self.__read()
+        self._apply_env_overrides()
         self.__set_directories()
         self.logger.debug("Settings\n%s", self)
+
+    def _apply_env_overrides(self):
+        self._apply_float_env_override(
+            "ISH_CLASSIFICATION_PROBABILITY_THRESHOLD",
+            "classification_probability_threshold",
+        )
+        self._apply_float_env_override(
+            "ISH_CLASSIFICATION_RUNNER_UP_GAP_THRESHOLD",
+            "classification_runner_up_gap_threshold",
+        )
+
+    def _apply_float_env_override(self, env_key: str, setting_key: str) -> None:
+        raw_value = os.environ.get(env_key)
+        if raw_value in (None, ""):
+            return
+        try:
+            self[setting_key] = float(raw_value)
+        except ValueError:
+            self.logger.warning("Ignoring invalid float for %s: %s", env_key, raw_value)
 
     # New helper methods referenced by ish.py (no-op / sane defaults)
     def update_data_settings(self):

--- a/tests/test_ish.py
+++ b/tests/test_ish.py
@@ -111,12 +111,9 @@ def test_classify_messages_skips_when_probability_low(monkeypatch):
     class LowProbClassifier:
         classes_ = ["destA", "destB"]
 
-        def predict(self, X):
-            return ["destA"]
-
         def predict_proba(self, X):
-            # Low top probability so it will be skipped (< 0.25)
-            return [[0.1, 0.05]]
+            # Top probability stays below the configured minimum.
+            return [[0.52, 0.48]]
 
     ish_instance.classifier = LowProbClassifier()
     ish_instance.get_embeddings = mock.MagicMock(return_value={99: np.array([0.1])})
@@ -157,6 +154,137 @@ def test_classify_messages_skips_when_runner_up_is_too_close(monkeypatch):
 
     assert ish_instance.skipped >= 1
     ish_instance._classification_service.move_messages.assert_called_once_with("INBOX", {})
+
+
+def test_classify_messages_logs_specific_reason_when_runner_up_is_too_close(monkeypatch, caplog):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [104]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class AmbiguousClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict_proba(self, X):
+            return [[0.56, 0.44]]
+
+    ish_instance.classifier = AmbiguousClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={104: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={104: Message(uid=104, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
+
+    with caplog.at_level("DEBUG", logger="ish"):
+        ish_instance.classify_messages(["INBOX"])
+
+    assert "Skipping due to ambiguous top prediction" in caplog.text
+    assert "runner_up=0.44" in caplog.text
+    assert "min_gap=0.15" in caplog.text
+
+
+def test_classify_messages_moves_when_gap_meets_threshold(monkeypatch):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [102]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class ClearEnoughClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict_proba(self, X):
+            # Clears both thresholds with room for float precision.
+            return [[0.58, 0.42]]
+
+    ish_instance.classifier = ClearEnoughClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={102: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={102: Message(uid=102, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=1)
+
+    ish_instance.classify_messages(["INBOX"])
+
+    assert ish_instance.skipped == 0
+    ish_instance._classification_service.move_messages.assert_called_once()
+
+
+def test_classify_messages_skips_when_probability_equals_threshold(monkeypatch):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [103]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class ThresholdEdgeClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict_proba(self, X):
+            return [[0.55, 0.45]]
+
+    ish_instance.classifier = ThresholdEdgeClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={103: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={103: Message(uid=103, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
+
+    ish_instance.classify_messages(["INBOX"])
+
+    assert ish_instance.skipped >= 1
+    ish_instance._classification_service.move_messages.assert_called_once_with("INBOX", {})
+
+
+def test_classify_messages_logs_specific_reason_when_probability_too_low(monkeypatch, caplog):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [105]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class ThresholdEdgeClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict_proba(self, X):
+            return [[0.55, 0.45]]
+
+    ish_instance.classifier = ThresholdEdgeClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={105: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={105: Message(uid=105, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
+
+    with caplog.at_level("DEBUG", logger="ish"):
+        ish_instance.classify_messages(["INBOX"])
+
+    assert "Skipping due to low confidence" in caplog.text
+    assert "top=0.55" in caplog.text
+    assert "min=0.55" in caplog.text
+
+
+def test_ish_reads_thresholds_from_settings(monkeypatch):
+    fake_settings = SimpleNamespace(
+        data_directory="/tmp/data",
+        source_folders=["INBOX"],
+        destination_folders=["Important"],
+        ignore_folders=[],
+        openai_api_key="key",
+        openai_model="text-embedding-3-small",
+        classification_probability_threshold=0.72,
+        classification_runner_up_gap_threshold=0.21,
+    )
+    fake_settings.update_data_settings = lambda: None
+    monkeypatch.setattr(ish_mod, "Settings", lambda debug=False: fake_settings)
+    monkeypatch.setattr(ish_mod, "SQLiteCache", mock.MagicMock())
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *args, **kwargs: mock.MagicMock())
+
+    ish_instance = ISH(dry_run=True)
+
+    assert ish_instance._classification_service._probability_threshold == pytest.approx(0.72)
+    assert ish_instance._classification_service._runner_up_gap_threshold == pytest.approx(0.21)
 
 
 def make_handler_with_mock_conn():
@@ -212,6 +340,8 @@ def test_run_calls_learn_when_no_model_file(tmp_path, monkeypatch):
         ignore_folders=[],
         openai_api_key="key",
         openai_model="text-embedding-ada-002",
+        classification_probability_threshold=0.55,
+        classification_runner_up_gap_threshold=0.15,
     )
     fake_settings.update_data_settings = lambda: None
     monkeypatch.setattr(ish_mod, "Settings", lambda debug=False: fake_settings)

--- a/tests/test_ish.py
+++ b/tests/test_ish.py
@@ -128,6 +128,37 @@ def test_classify_messages_skips_when_probability_low(monkeypatch):
     ish_instance._classification_service.move_messages.assert_called()
 
 
+def test_classify_messages_skips_when_runner_up_is_too_close(monkeypatch):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [101]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class AmbiguousClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict(self, X):
+            return ["destA"]
+
+        def predict_proba(self, X):
+            # Top prediction clears the minimum probability threshold,
+            # but the runner-up is too close to move safely.
+            return [[0.56, 0.44]]
+
+    ish_instance.classifier = AmbiguousClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={101: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={101: Message(uid=101, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
+
+    ish_instance.classify_messages(["INBOX"])
+
+    assert ish_instance.skipped >= 1
+    ish_instance._classification_service.move_messages.assert_called_once_with("INBOX", {})
+
+
 def make_handler_with_mock_conn():
     handler = ImapHandler(settings=mock.MagicMock(), readonly=False) # pyright: ignore[reportUndefinedVariable]
     conn = mock.MagicMock()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,8 +2,16 @@ import os
 
 from ish.settings import Settings
 
+
+def make_settings(tmp_path, monkeypatch):
+    cfg = tmp_path / ".ish"
+    cfg.mkdir(exist_ok=True)
+    monkeypatch.setenv("ISH_CONFIG_PATH", str(cfg))
+    return Settings(debug=True)
+
+
 def test_update_folder_settings_adds_missing_keys(tmp_path, monkeypatch):
-    s = Settings(debug=True)
+    s = make_settings(tmp_path, monkeypatch)
     # Clear any potential keys
     if "source_folders" in s:
         del s["source_folders"]
@@ -21,9 +29,8 @@ def test_update_folder_settings_adds_missing_keys(tmp_path, monkeypatch):
 def test_update_data_settings_creates_data_dir(tmp_path, monkeypatch):
     cfg = tmp_path / ".ish"
     os.makedirs(cfg, exist_ok=True)
-    settings_file = cfg / "settings.yaml"
 
-    s = Settings(debug=True)
+    s = make_settings(tmp_path, monkeypatch)
     s.config_directory = str(cfg)
     s["data_directory"] = str(cfg / "data-dir-test")
     # ensure cleanup if present
@@ -32,3 +39,20 @@ def test_update_data_settings_creates_data_dir(tmp_path, monkeypatch):
 
     s.update_data_settings()
     assert os.path.isdir(s["data_directory"])
+
+
+def test_classification_threshold_defaults_are_present(tmp_path, monkeypatch):
+    s = make_settings(tmp_path, monkeypatch)
+
+    assert s.classification_probability_threshold == 0.55
+    assert s.classification_runner_up_gap_threshold == 0.15
+
+
+def test_classification_threshold_env_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("ISH_CLASSIFICATION_PROBABILITY_THRESHOLD", "0.8")
+    monkeypatch.setenv("ISH_CLASSIFICATION_RUNNER_UP_GAP_THRESHOLD", "0.22")
+
+    s = make_settings(tmp_path, monkeypatch)
+
+    assert s.classification_probability_threshold == 0.8
+    assert s.classification_runner_up_gap_threshold == 0.22


### PR DESCRIPTION
## Summary
- Add configurable thresholds for classification confidence and runner-up gap, wired through settings into the move decision path
- Extract the move policy into a small helper and improve skip logging with explicit reasons and numeric context
- Add regression coverage for threshold boundaries, skip reasons, and settings/env wiring
- Document the new configuration knobs in the README

## Testing
- Added and updated unit tests for threshold behavior, log messages, and settings defaults/overrides
- Local test suite passed for `tests/test_ish.py`, `tests/test_settings.py`, and the full `tests/` suite