### PR TITLE
fix: improve training and embedding cache quality

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "type": "debugpy",
       "request": "launch",
       "program": "${file}",
-      "console": "integratedTerminal"
+      "console": "integratedTerminal",
+      "envFile": "${workspaceFolder}/.vscode/test.env"
     },
     {
       "name": "ISH learn",
@@ -39,7 +40,8 @@
         "-v"
       ],
       "env": {
-        "ISH_CONFIG_PATH": "dummy"
+        "ISH_CONFIG_PATH": "${workspaceFolder}/.ish-dev",
+        "PYTHONPATH": "${workspaceFolder}/src"
       }
     },
     {
@@ -49,6 +51,10 @@
       "module": "ish.app",
       "cwd": "${workspaceFolder}",
       "justMyCode": true,
+      "env": {
+        "ISH_CONFIG_PATH": "${workspaceFolder}/.ish-dev",
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
       "args": [
         "-v",
         "-D",
@@ -63,6 +69,7 @@
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
       "justMyCode": false,
+      "envFile": "${workspaceFolder}/.vscode/test.env",
       "args": [
         //"--dry-run"
       ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,13 @@
     "python.analysis.inlayHints.functionReturnTypes": false,
     "python.analysis.inlayHints.variableTypes": true,
     "python.analysis.inlayHints.pytestParameters": false,
-    "python.analysis.enablePytestSupport": false,
+    "python.analysis.enablePytestSupport": true,
     "editor.formatOnSave": true,
     "python.terminal.activateEnvironment": true,
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.envFile": "${workspaceFolder}/.vscode/test.env",
+    "python.testing.cwd": "${workspaceFolder}",
+    "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
     "python.analysis.extraPaths": [
         "./src"
     ],

--- a/.vscode/test.env
+++ b/.vscode/test.env
@@ -1,0 +1,3 @@
+PYTHONPATH=src
+ISH_CONFIG_PATH=/tmp/ish-vscode-test
+ISH_METRICS_PORT=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/src/ish/app.py
+++ b/src/ish/app.py
@@ -33,7 +33,7 @@ from itertools import batched  # Python 3.12+
 
 from . import metrics
 from .classification_service import ClassificationService
-from .embedding_store import EMBEDDING_INPUT_PROFILE, EmbeddingStore
+from .embedding_store import EmbeddingStore, embedding_profile_for_model
 from .imap import ImapHandler
 from .message import Message  # added
 from .settings import Settings
@@ -94,6 +94,7 @@ class ISH:
         self._maybe_migrate_legacy_cache()
         self._cache = SQLiteCache(self._db_file)
         metrics.record_db_size(self._db_file)
+        self._embedding_profile = embedding_profile_for_model(self.__settings.openai_model)
 
         self._message_repository = MessageRepository(
             cache=self._cache,
@@ -104,19 +105,21 @@ class ISH:
             message_repository=self._message_repository,
             embedder=lambda texts: self.__get_embeddings(texts),
             max_chars=EMBED_MAX_CHARS,
-            data_directory=self.__settings.data_directory
+            data_directory=self.__settings.data_directory,
+            embedding_profile=self._embedding_profile,
         )
         self._training_manager = TrainingManager(
             imap_conn_provider=lambda: self.__imap_conn,
             get_embeddings=lambda folder, uids: self.get_embeddings(folder, uids),
             get_cache_embeddings=(
                 lambda folder: self._cache.get_folder_embeddings(
-                    folder, EMBEDDING_INPUT_PROFILE
+                    folder, self._embedding_profile
                 )
             ),
             model_file=self.model_file,
             max_learn_messages=MAX_LEARN_MESSAGES,
-            exit_event=self._exit_event
+            exit_event=self._exit_event,
+            embedding_profile=self._embedding_profile,
         )
         self._classification_service = ClassificationService(
             imap_conn_provider=lambda: self.__imap_conn,
@@ -129,6 +132,7 @@ class ISH:
             exit_event=self._exit_event,
             probability_threshold=self.__settings.classification_probability_threshold,
             runner_up_gap_threshold=self.__settings.classification_runner_up_gap_threshold,
+            embedding_profile=self._embedding_profile,
         )
 
         self.moved = 0
@@ -344,9 +348,9 @@ class ISH:
         if not self.connect():
             return 1
         
-        if not os.path.isfile(self.model_file):
+        if not self._classification_service.has_compatible_classifier():
             self.logger.info(
-                "No classifier at %s. Going to learning folders.",
+                "No compatible classifier at %s. Going to learning folders.",
                 self.model_file,
             )
             if not self.train_on_destination_folders():

--- a/src/ish/app.py
+++ b/src/ish/app.py
@@ -33,7 +33,7 @@ from itertools import batched  # Python 3.12+
 
 from . import metrics
 from .classification_service import ClassificationService
-from .embedding_store import EmbeddingStore
+from .embedding_store import EMBEDDING_INPUT_PROFILE, EmbeddingStore
 from .imap import ImapHandler
 from .message import Message  # added
 from .settings import Settings
@@ -109,7 +109,11 @@ class ISH:
         self._training_manager = TrainingManager(
             imap_conn_provider=lambda: self.__imap_conn,
             get_embeddings=lambda folder, uids: self.get_embeddings(folder, uids),
-            get_cache_embeddings=self._cache.get_folder_embeddings,
+            get_cache_embeddings=(
+                lambda folder: self._cache.get_folder_embeddings(
+                    folder, EMBEDDING_INPUT_PROFILE
+                )
+            ),
             model_file=self.model_file,
             max_learn_messages=MAX_LEARN_MESSAGES,
             exit_event=self._exit_event

--- a/src/ish/classification_service.py
+++ b/src/ish/classification_service.py
@@ -80,6 +80,7 @@ class ClassificationService:
                 if not self._interactive
                 else imap_conn.search(source_folder, ["ALL"])
             )
+            uids = sorted(uids, reverse=True)
 
             embeddings = self._get_embeddings(source_folder, uids[: self._max_source_messages])
             metrics.record_folder_embedding_count(source_folder, len(embeddings))

--- a/src/ish/classification_service.py
+++ b/src/ish/classification_service.py
@@ -9,8 +9,10 @@ import numpy as np
 from sklearn.ensemble import RandomForestClassifier
 
 from . import metrics
+from .embedding_store import EMBEDDING_INPUT_PROFILE
 from .imap import ImapHandler
 from .message import Message
+from .model_store import unpack_model_bundle
 from .settings import (
     DEFAULT_CLASSIFICATION_PROBABILITY_THRESHOLD,
     DEFAULT_CLASSIFICATION_RUNNER_UP_GAP_THRESHOLD,
@@ -36,6 +38,7 @@ class ClassificationService:
         logger: Optional[logging.Logger] = None,
         probability_threshold: float = DEFAULT_CLASSIFICATION_PROBABILITY_THRESHOLD,
         runner_up_gap_threshold: float = DEFAULT_CLASSIFICATION_RUNNER_UP_GAP_THRESHOLD,
+        embedding_profile: str = EMBEDDING_INPUT_PROFILE,
     ) -> None:
         self._imap_conn_provider = imap_conn_provider
         self._get_embeddings = get_embeddings
@@ -47,6 +50,7 @@ class ClassificationService:
         self._exit_event = exit_event
         self._probability_threshold = probability_threshold
         self._runner_up_gap_threshold = runner_up_gap_threshold
+        self._embedding_profile = embedding_profile
         self._logger = logger or logging.getLogger("ish").getChild(self.__class__.__name__)
 
         self._classifier: Optional[RandomForestClassifier] = None
@@ -173,11 +177,21 @@ class ClassificationService:
             return None
 
         try:
-            self._classifier = joblib.load(self._model_file)
+            payload = joblib.load(self._model_file)
         except Exception as exc:
             self._logger.error("Failed to load classifier from %s: %s", self._model_file, exc)
             return None
+
+        classifier, error = unpack_model_bundle(payload, self._embedding_profile)
+        if error:
+            self._logger.error("Failed to load classifier from %s: %s", self._model_file, error)
+            return None
+
+        self._classifier = classifier
         return self._classifier
+
+    def has_compatible_classifier(self) -> bool:
+        return self._ensure_classifier() is not None
 
     def _increment_skipped(self, amount: int = 1) -> None:
         self.skipped += amount

--- a/src/ish/db.py
+++ b/src/ish/db.py
@@ -1,11 +1,14 @@
 import os
 import pickle
 import sqlite3
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 import numpy as np
 
 from .message import Message
+
+LEGACY_EMBEDDING_PROFILE = "legacy-body-v1"
 
 
 class SQLiteCache:
@@ -36,13 +39,50 @@ class SQLiteCache:
                 FOREIGN KEY (msg_hash) REFERENCES messages_content(msg_hash) ON DELETE CASCADE
             );
             CREATE TABLE IF NOT EXISTS embeddings (
-                msg_hash TEXT PRIMARY KEY,
+                msg_hash TEXT,
+                profile TEXT NOT NULL DEFAULT 'legacy-body-v1',
                 data BLOB,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (msg_hash, profile),
                 FOREIGN KEY (msg_hash) REFERENCES messages_content(msg_hash) ON DELETE CASCADE
             );
             """
         )
+        self._migrate_embedding_schema()
         self.conn.commit()
+
+    def _migrate_embedding_schema(self):
+        cur = self.conn.cursor()
+        cur.execute("PRAGMA table_info(embeddings)")
+        columns = {row[1] for row in cur.fetchall()}
+        if "profile" not in columns:
+            cur.executescript(
+                f"""
+                ALTER TABLE embeddings RENAME TO embeddings_legacy;
+                CREATE TABLE embeddings (
+                    msg_hash TEXT,
+                    profile TEXT NOT NULL DEFAULT '{LEGACY_EMBEDDING_PROFILE}',
+                    data BLOB,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (msg_hash, profile),
+                    FOREIGN KEY (msg_hash) REFERENCES messages_content(msg_hash) ON DELETE CASCADE
+                );
+                INSERT INTO embeddings (msg_hash, profile, data, created_at, updated_at)
+                SELECT msg_hash, '{LEGACY_EMBEDDING_PROFILE}', data, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                FROM embeddings_legacy;
+                DROP TABLE embeddings_legacy;
+                """
+            )
+            return
+
+        for column in ("created_at", "updated_at"):
+            if column not in columns:
+                cur.execute(f"ALTER TABLE embeddings ADD COLUMN {column} TEXT")
+                cur.execute(
+                    f"UPDATE embeddings SET {column} = CURRENT_TIMESTAMP WHERE {column} IS NULL"
+                )
 
     def close(self):
         try:
@@ -115,25 +155,45 @@ class SQLiteCache:
 
     # Embeddings
 
-    def get_embedding(self, msg_hash: str) -> Optional[np.ndarray]:
+    @staticmethod
+    def _timestamp() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def get_embedding(
+        self, msg_hash: str, profile: str = LEGACY_EMBEDDING_PROFILE
+    ) -> Optional[np.ndarray]:
         cur = self.conn.cursor()
-        cur.execute("SELECT data FROM embeddings WHERE msg_hash = ? LIMIT 1", (msg_hash,))
+        cur.execute(
+            "SELECT data FROM embeddings WHERE msg_hash = ? AND profile = ? LIMIT 1",
+            (msg_hash, profile),
+        )
         r = cur.fetchone()
         if not r:
             return None
         data = r[0]
         return pickle.loads(data)
 
-    def store_embedding(self, msg_hash: str, emb: np.ndarray):
+    def store_embedding(
+        self, msg_hash: str, emb: np.ndarray, profile: str = LEGACY_EMBEDDING_PROFILE
+    ):
         cur = self.conn.cursor()
         pickled = pickle.dumps(emb, protocol=pickle.HIGHEST_PROTOCOL)
+        timestamp = self._timestamp()
         cur.execute(
-            "INSERT OR REPLACE INTO embeddings (msg_hash, data) VALUES (?, ?)",
-            (msg_hash, sqlite3.Binary(pickled)),
+            """
+            INSERT INTO embeddings (msg_hash, profile, data, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(msg_hash, profile) DO UPDATE SET
+                data = excluded.data,
+                updated_at = excluded.updated_at
+            """,
+            (msg_hash, profile, sqlite3.Binary(pickled), timestamp, timestamp),
         )
         self.conn.commit()
 
-    def get_folder_embeddings(self, folder: str) -> Dict[int, np.ndarray]:
+    def get_folder_embeddings(
+        self, folder: str, profile: str = LEGACY_EMBEDDING_PROFILE
+    ) -> Dict[int, np.ndarray]:
         """Return all cached embeddings for a folder keyed by UID."""
         cur = self.conn.cursor()
         cur.execute(
@@ -141,9 +201,9 @@ class SQLiteCache:
             SELECT fm.uid, e.data
             FROM folder_messages fm
             JOIN embeddings e ON fm.msg_hash = e.msg_hash
-            WHERE fm.folder = ?
+            WHERE fm.folder = ? AND e.profile = ?
             """,
-            (folder,),
+            (folder, profile),
         )
         out: Dict[int, np.ndarray] = {}
         for uid, data in cur.fetchall():

--- a/src/ish/embedding_store.py
+++ b/src/ish/embedding_store.py
@@ -10,6 +10,8 @@ from ish import metrics
 from .db import SQLiteCache
 from .message_repository import MessageRepository
 
+EMBEDDING_INPUT_PROFILE = "structured-message-v1"
+
 
 class EmbeddingStore:
     """Manage cached embeddings and fetch new ones via embedder callback."""
@@ -22,6 +24,7 @@ class EmbeddingStore:
         embedder: Callable[[List[str]], List[np.ndarray]],
         max_chars: int,
         data_directory: str,
+        embedding_profile: str = EMBEDDING_INPUT_PROFILE,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self._cache = cache
@@ -29,6 +32,7 @@ class EmbeddingStore:
         self._embedder = embedder
         self._max_chars = max_chars
         self._data_directory = data_directory
+        self._embedding_profile = embedding_profile
         self._logger = logger or logging.getLogger("ish").getChild(self.__class__.__name__)
 
     def get_embeddings(self, folder: str, uids: List[int]) -> Dict[int, np.ndarray]:
@@ -50,7 +54,7 @@ class EmbeddingStore:
         missing: List[int] = []
 
         for uid, msg_hash in hash_map.items():
-            embd = self._cache.get_embedding(msg_hash)
+            embd = self._cache.get_embedding(msg_hash, self._embedding_profile)
             if embd is not None:
                 embeddings[uid] = embd
             else:
@@ -78,7 +82,7 @@ class EmbeddingStore:
                     if msg_hash is None:
                         msg_hash = self._cache.store_message(folder, uid, message)
                         hash_map[uid] = msg_hash
-                    self._cache.store_embedding(msg_hash, emb)
+                    self._cache.store_embedding(msg_hash, emb, self._embedding_profile)
                     embeddings[uid] = emb
 
         self._logger.debug("Total embeddings found/added %i in %s.", len(embeddings), folder)

--- a/src/ish/embedding_store.py
+++ b/src/ish/embedding_store.py
@@ -66,7 +66,7 @@ class EmbeddingStore:
                 if message is None:
                     continue
                 ordered_uids.append(uid)
-                texts.append(message.body[: self._max_chars])
+                texts.append(message.embedding_text()[: self._max_chars])
 
             if texts:
                 embeddings_list = self._batch_embeddings(texts)

--- a/src/ish/embedding_store.py
+++ b/src/ish/embedding_store.py
@@ -10,7 +10,14 @@ from ish import metrics
 from .db import SQLiteCache
 from .message_repository import MessageRepository
 
-EMBEDDING_INPUT_PROFILE = "structured-message-v1"
+EMBEDDING_INPUT_FORMAT = "structured-message-v1"
+DEFAULT_EMBEDDING_MODEL = "text-embedding-ada-002"
+EMBEDDING_INPUT_PROFILE = f"{EMBEDDING_INPUT_FORMAT}:{DEFAULT_EMBEDDING_MODEL}"
+
+
+def embedding_profile_for_model(openai_model: str) -> str:
+    model = openai_model or DEFAULT_EMBEDDING_MODEL
+    return f"{EMBEDDING_INPUT_FORMAT}:{model}"
 
 
 class EmbeddingStore:

--- a/src/ish/message.py
+++ b/src/ish/message.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from hashlib import sha256
 import hashlib
 from typing import Optional
 
@@ -14,6 +13,16 @@ class Message:
 
     def preview(self, length: int = 100) -> str:
         return self.body[:length]
+
+    def embedding_text(self) -> str:
+        return "\n".join(
+            [
+                f"From: {self.from_addr or ''}",
+                f"To: {self.to_addr or ''}",
+                f"Subject: {self.subject or ''}",
+                f"Body: {self.body or ''}",
+            ]
+        )
 
     def hash(self) -> str:
         # Generate a short hash based on the message body and all the other fields

--- a/src/ish/migrate_shelve_to_sql.py
+++ b/src/ish/migrate_shelve_to_sql.py
@@ -25,7 +25,7 @@ from typing import Optional
 import numpy as np
 
 from .settings import Settings
-from .db import SQLiteCache
+from .db import LEGACY_EMBEDDING_PROFILE, SQLiteCache
 from .message import Message
 
 logger = logging.getLogger("ish.migrate")
@@ -70,8 +70,11 @@ def _insert_embedding_preserve_hash(conn: sqlite3.Connection, msg_hash: str, emb
     cur = conn.cursor()
     pickled = pickle.dumps(emb, protocol=pickle.HIGHEST_PROTOCOL)
     cur.execute(
-        "INSERT OR REPLACE INTO embeddings (msg_hash, data) VALUES (?, ?)",
-        (msg_hash, sqlite3.Binary(pickled)),
+        """
+        INSERT OR REPLACE INTO embeddings (msg_hash, profile, data)
+        VALUES (?, ?, ?)
+        """,
+        (msg_hash, LEGACY_EMBEDDING_PROFILE, sqlite3.Binary(pickled)),
     )
 
 
@@ -108,14 +111,21 @@ def _rehash_and_reconcile(conn: sqlite3.Connection) -> dict:
             if computed_exists:
                 # move folder_messages
                 cur.execute("UPDATE folder_messages SET msg_hash = ? WHERE msg_hash = ?", (computed, old_hash))
-                # move embedding only if computed doesn't have embedding
-                cur.execute("SELECT data FROM embeddings WHERE msg_hash = ? LIMIT 1", (old_hash,))
-                emb_old = cur.fetchone()
-                cur.execute("SELECT 1 FROM embeddings WHERE msg_hash = ? LIMIT 1", (computed,))
-                emb_new_exists = cur.fetchone() is not None
-                if emb_old and not emb_new_exists:
-                    cur.execute("INSERT OR REPLACE INTO embeddings (msg_hash, data) VALUES (?, ?)", (computed, emb_old[0]))
-                    cur.execute("DELETE FROM embeddings WHERE msg_hash = ?", (old_hash,))
+                # move legacy embeddings while preserving their profile
+                cur.execute(
+                    "SELECT profile, data, created_at, updated_at FROM embeddings WHERE msg_hash = ?",
+                    (old_hash,),
+                )
+                for profile, data, created_at, updated_at in cur.fetchall():
+                    cur.execute(
+                        """
+                        INSERT OR IGNORE INTO embeddings
+                            (msg_hash, profile, data, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, ?)
+                        """,
+                        (computed, profile, data, created_at, updated_at),
+                    )
+                cur.execute("DELETE FROM embeddings WHERE msg_hash = ?", (old_hash,))
                 # delete old content
                 cur.execute("DELETE FROM messages_content WHERE msg_hash = ?", (old_hash,))
                 merged += 1
@@ -127,11 +137,20 @@ def _rehash_and_reconcile(conn: sqlite3.Connection) -> dict:
                 )
                 # move folder_messages and embedding
                 cur.execute("UPDATE folder_messages SET msg_hash = ? WHERE msg_hash = ?", (computed, old_hash))
-                cur.execute("SELECT data FROM embeddings WHERE msg_hash = ? LIMIT 1", (old_hash,))
-                emb_old = cur.fetchone()
-                if emb_old:
-                    cur.execute("INSERT OR REPLACE INTO embeddings (msg_hash, data) VALUES (?, ?)", (computed, emb_old[0]))
-                    cur.execute("DELETE FROM embeddings WHERE msg_hash = ?", (old_hash,))
+                cur.execute(
+                    "SELECT profile, data, created_at, updated_at FROM embeddings WHERE msg_hash = ?",
+                    (old_hash,),
+                )
+                for profile, data, created_at, updated_at in cur.fetchall():
+                    cur.execute(
+                        """
+                        INSERT OR REPLACE INTO embeddings
+                            (msg_hash, profile, data, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, ?)
+                        """,
+                        (computed, profile, data, created_at, updated_at),
+                    )
+                cur.execute("DELETE FROM embeddings WHERE msg_hash = ?", (old_hash,))
                 cur.execute("DELETE FROM messages_content WHERE msg_hash = ?", (old_hash,))
                 updated += 1
 

--- a/src/ish/model_store.py
+++ b/src/ish/model_store.py
@@ -1,0 +1,33 @@
+MODEL_BUNDLE_VERSION = 1
+
+
+def make_model_bundle(classifier, embedding_profile: str) -> dict:
+    return {
+        "version": MODEL_BUNDLE_VERSION,
+        "embedding_profile": embedding_profile,
+        "classifier": classifier,
+    }
+
+
+def unpack_model_bundle(payload, expected_embedding_profile: str):
+    if not isinstance(payload, dict):
+        return None, "classifier file does not include embedding profile metadata"
+
+    if payload.get("version") != MODEL_BUNDLE_VERSION:
+        return None, "classifier file has an unsupported bundle version"
+
+    actual_embedding_profile = payload.get("embedding_profile")
+    if actual_embedding_profile != expected_embedding_profile:
+        return (
+            None,
+            (
+                "classifier embedding profile mismatch "
+                f"(found={actual_embedding_profile}, expected={expected_embedding_profile})"
+            ),
+        )
+
+    classifier = payload.get("classifier")
+    if classifier is None:
+        return None, "classifier bundle does not contain a classifier"
+
+    return classifier, None

--- a/src/ish/training_manager.py
+++ b/src/ish/training_manager.py
@@ -1,10 +1,12 @@
 import logging
+from collections import Counter
 from threading import Event
 from time import perf_counter
 from typing import Callable, Dict, List, Optional
 
 import joblib
 import numpy as np
+from sklearn.calibration import CalibratedClassifierCV
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import classification_report
 from sklearn.model_selection import train_test_split
@@ -35,7 +37,7 @@ class TrainingManager:
         self._exit_event = exit_event
         self._logger = logger or logging.getLogger("ish").getChild(self.__class__.__name__)
 
-    def learn_folders(self, folders: List[str]) -> Optional[RandomForestClassifier]:
+    def learn_folders(self, folders: List[str]) -> Optional[RandomForestClassifier | CalibratedClassifierCV]:
         """Train a classifier from the provided folders."""
         imap_conn = self._imap_conn_provider()
         fetch_start = perf_counter()
@@ -53,7 +55,7 @@ class TrainingManager:
 
         X = np.array(embed_array)
         y = np.array(folder_array)
-        X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+        X_train, X_test, y_train, y_test = self._split_training_data(X, y)
 
         clf = self._train_classifier(X_train, y_train)
         accuracy = self._evaluate_classifier(clf, X_test, y_test, folders)
@@ -77,10 +79,13 @@ class TrainingManager:
         for folder in folders:
             self._logger.info("Learning folder %s", folder)
             uids = imap_conn.search(folder, ["ALL"])
-            embeddings = self._get_embeddings(folder, uids[: self._max_learn_messages])
+            current_uids = uids[: self._max_learn_messages]
+            current_uid_set = set(current_uids)
+            embeddings = self._get_embeddings(folder, current_uids)
             cached_embeddings = self._get_cache_embeddings(folder)
             for uid, emb in cached_embeddings.items():
-                embeddings.setdefault(uid, emb)
+                if uid in current_uid_set:
+                    embeddings.setdefault(uid, emb)
             if len(embeddings) == 0:
                 self._logger.warning("No embeddings available for folder %s; skipping.", folder)
                 continue
@@ -116,16 +121,49 @@ class TrainingManager:
             "Fetched %i embeddings in %.2f seconds", total_embeddings, duration
         )
 
+    def _split_training_data(
+        self, X: np.ndarray, y: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        label_counts = Counter(y)
+        label_count = len(label_counts)
+        can_stratify = (
+            len(y) >= label_count * 2
+            and all(count >= 2 for count in label_counts.values())
+        )
+        if not can_stratify:
+            self._logger.warning(
+                "Training data is too sparse to stratify safely; using an unstratified validation split."
+            )
+            return train_test_split(X, y, random_state=0)
+
+        test_size = max(0.25, label_count / len(y))
+        test_size = min(test_size, 0.5)
+        return train_test_split(X, y, random_state=0, stratify=y, test_size=test_size)
+
     def _train_classifier(
         self, X_train: np.ndarray, y_train: np.ndarray
-    ) -> RandomForestClassifier:
-        clf = RandomForestClassifier(n_estimators=100, random_state=0)
-        clf.fit(X_train, y_train)
-        return clf
+    ) -> RandomForestClassifier | CalibratedClassifierCV:
+        base_clf = RandomForestClassifier(
+            n_estimators=100,
+            random_state=0,
+            class_weight="balanced",
+        )
+        label_counts = Counter(y_train)
+        calibration_folds = min(3, min(label_counts.values()))
+        if calibration_folds >= 2:
+            clf = CalibratedClassifierCV(base_clf, cv=calibration_folds)
+            clf.fit(X_train, y_train)
+            return clf
+
+        self._logger.warning(
+            "Training data is too sparse to calibrate probabilities; using raw RandomForest probabilities."
+        )
+        base_clf.fit(X_train, y_train)
+        return base_clf
 
     def _evaluate_classifier(
         self,
-        clf: RandomForestClassifier,
+        clf: RandomForestClassifier | CalibratedClassifierCV,
         X_test: np.ndarray,
         y_test: np.ndarray,
         folders: List[str],
@@ -146,7 +184,10 @@ class TrainingManager:
         return accuracy
 
     def _log_training_summary(
-        self, total_embeddings: int, accuracy: float, clf: RandomForestClassifier
+        self,
+        total_embeddings: int,
+        accuracy: float,
+        clf: RandomForestClassifier | CalibratedClassifierCV,
     ) -> None:
         self._logger.info("Trained with %i embeddings", total_embeddings)
         self._logger.info("Accuracy: %.2f", accuracy)

--- a/src/ish/training_manager.py
+++ b/src/ish/training_manager.py
@@ -13,6 +13,7 @@ from sklearn.model_selection import train_test_split
 
 from . import metrics
 from .imap import ImapHandler
+from .model_store import make_model_bundle
 
 
 class TrainingManager:
@@ -27,6 +28,7 @@ class TrainingManager:
         model_file: str,
         max_learn_messages: int,
         exit_event: Event,
+        embedding_profile: str,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         self._imap_conn_provider = imap_conn_provider
@@ -35,6 +37,7 @@ class TrainingManager:
         self._model_file = model_file
         self._max_learn_messages = max_learn_messages
         self._exit_event = exit_event
+        self._embedding_profile = embedding_profile
         self._logger = logger or logging.getLogger("ish").getChild(self.__class__.__name__)
 
     def learn_folders(self, folders: List[str]) -> Optional[RandomForestClassifier | CalibratedClassifierCV]:
@@ -65,7 +68,7 @@ class TrainingManager:
         duration = eval_end - fetch_end
         metrics.record_training_stats(len(embed_array), accuracy, duration)
 
-        joblib.dump(clf, self._model_file)
+        joblib.dump(make_model_bundle(clf, self._embedding_profile), self._model_file)
         self._logger.info("Saved classifier.")
         return clf
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+
+os.environ.setdefault("ISH_CONFIG_PATH", "/tmp/ish-test-config")
+os.environ.setdefault("ISH_METRICS_PORT", "")

--- a/tests/test_cache_migration.py
+++ b/tests/test_cache_migration.py
@@ -1,0 +1,114 @@
+import pickle
+import sqlite3
+
+import numpy as np
+
+from ish.db import LEGACY_EMBEDDING_PROFILE, SQLiteCache
+from ish.embedding_store import EMBEDDING_INPUT_PROFILE
+from ish.message import Message
+from ish.migrate_shelve_to_sql import _rehash_and_reconcile
+
+
+def test_sqlite_cache_migrates_legacy_embedding_schema_with_profile_and_timestamps(tmp_path):
+    db_path = tmp_path / "cache.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE messages_content (
+            msg_hash TEXT PRIMARY KEY,
+            from_addr TEXT,
+            to_addr TEXT,
+            subject TEXT,
+            body TEXT
+        );
+        CREATE TABLE folder_messages (
+            folder TEXT,
+            uid INTEGER,
+            msg_hash TEXT,
+            PRIMARY KEY (folder, uid),
+            FOREIGN KEY (msg_hash) REFERENCES messages_content(msg_hash) ON DELETE CASCADE
+        );
+        CREATE TABLE embeddings (
+            msg_hash TEXT PRIMARY KEY,
+            data BLOB,
+            FOREIGN KEY (msg_hash) REFERENCES messages_content(msg_hash) ON DELETE CASCADE
+        );
+        """
+    )
+    message = Message(uid=1, from_addr="a", to_addr="b", subject="s", body="body")
+    msg_hash = message.hash()
+    conn.execute(
+        "INSERT INTO messages_content (msg_hash, from_addr, to_addr, subject, body) VALUES (?, ?, ?, ?, ?)",
+        (msg_hash, message.from_addr, message.to_addr, message.subject, message.body),
+    )
+    conn.execute(
+        "INSERT INTO embeddings (msg_hash, data) VALUES (?, ?)",
+        (msg_hash, sqlite3.Binary(pickle.dumps(np.array([1.0])))),
+    )
+    conn.commit()
+    conn.close()
+
+    cache = SQLiteCache(str(db_path))
+    cur = cache.conn.cursor()
+    cur.execute("PRAGMA table_info(embeddings)")
+    columns = {row[1] for row in cur.fetchall()}
+    cur.execute("SELECT profile, created_at, updated_at FROM embeddings WHERE msg_hash = ?", (msg_hash,))
+    profile, created_at, updated_at = cur.fetchone()
+
+    assert {"msg_hash", "profile", "data", "created_at", "updated_at"}.issubset(columns)
+    assert profile == LEGACY_EMBEDDING_PROFILE
+    assert created_at
+    assert updated_at
+    assert cache.get_embedding(msg_hash, EMBEDDING_INPUT_PROFILE) is None
+    assert cache.get_embedding(msg_hash, LEGACY_EMBEDDING_PROFILE).tolist() == [1.0]
+
+
+def test_rehash_preserves_embedding_profile_and_timestamps(tmp_path):
+    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
+    conn = cache.conn
+    message = Message(uid=1, from_addr="a", to_addr="b", subject="s", body="body")
+    old_hash = "legacy-hash"
+    computed_hash = message.hash()
+    created_at = "2024-01-01T00:00:00+00:00"
+    updated_at = "2024-02-01T00:00:00+00:00"
+
+    conn.execute(
+        "INSERT INTO messages_content (msg_hash, from_addr, to_addr, subject, body) VALUES (?, ?, ?, ?, ?)",
+        (old_hash, message.from_addr, message.to_addr, message.subject, message.body),
+    )
+    conn.execute(
+        "INSERT INTO folder_messages (folder, uid, msg_hash) VALUES (?, ?, ?)",
+        ("INBOX", 1, old_hash),
+    )
+    conn.execute(
+        """
+        INSERT INTO embeddings (msg_hash, profile, data, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            old_hash,
+            LEGACY_EMBEDDING_PROFILE,
+            sqlite3.Binary(pickle.dumps(np.array([1.0]))),
+            created_at,
+            updated_at,
+        ),
+    )
+    conn.commit()
+
+    assert _rehash_and_reconcile(conn) == {"updated": 1, "merged": 0, "skipped": 0}
+
+    cur = conn.cursor()
+    cur.execute("SELECT msg_hash FROM folder_messages WHERE folder = ? AND uid = ?", ("INBOX", 1))
+    assert cur.fetchone()[0] == computed_hash
+    cur.execute(
+        "SELECT profile, data, created_at, updated_at FROM embeddings WHERE msg_hash = ?",
+        (computed_hash,),
+    )
+    profile, data, stored_created_at, stored_updated_at = cur.fetchone()
+
+    assert profile == LEGACY_EMBEDDING_PROFILE
+    assert pickle.loads(data).tolist() == [1.0]
+    assert stored_created_at == created_at
+    assert stored_updated_at == updated_at
+    cur.execute("SELECT 1 FROM messages_content WHERE msg_hash = ?", (old_hash,))
+    assert cur.fetchone() is None

--- a/tests/test_classification_service.py
+++ b/tests/test_classification_service.py
@@ -1,0 +1,258 @@
+from threading import Event
+from unittest import mock
+
+import joblib
+import numpy as np
+
+import ish.app as ish_mod
+from ish.app import ISH
+from ish.classification_service import ClassificationService
+from ish.embedding_store import embedding_profile_for_model
+from ish.message import Message
+from ish.model_store import make_model_bundle
+
+
+def test_classify_messages_moves_high_probability_and_skips_low(monkeypatch):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [42]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class DummyClassifier:
+        classes_ = ["dest1", "dest2"]
+
+        def predict(self, X):
+            return ["dest1"]
+
+        def predict_proba(self, X):
+            return [[0.8, 0.2]]
+
+    test_msg = Message(
+        uid=42,
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        body="Hello world",
+        subject="Test",
+    )
+
+    ish_instance.classifier = DummyClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={42: np.array([0.1, 0.2, 0.3])})
+    ish_instance.get_msgs = mock.MagicMock(return_value={42: test_msg})
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=1)
+
+    ish_instance.classify_messages(["INBOX"])
+    ish_instance._classification_service.move_messages.assert_called()
+    assert ish_instance.moved >= 0
+
+
+def test_classify_messages_skips_when_probability_low(monkeypatch):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [99]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class LowProbClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict_proba(self, X):
+            return [[0.52, 0.48]]
+
+    ish_instance.classifier = LowProbClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={99: np.array([0.1])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={99: Message(uid=99, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
+
+    ish_instance.classify_messages(["INBOX"])
+    assert ish_instance.skipped >= 1
+    ish_instance._classification_service.move_messages.assert_called()
+
+
+def test_classify_messages_skips_when_runner_up_is_too_close(monkeypatch):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [101]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class AmbiguousClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict(self, X):
+            return ["destA"]
+
+        def predict_proba(self, X):
+            return [[0.56, 0.44]]
+
+    ish_instance.classifier = AmbiguousClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={101: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={101: Message(uid=101, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
+
+    ish_instance.classify_messages(["INBOX"])
+
+    assert ish_instance.skipped >= 1
+    ish_instance._classification_service.move_messages.assert_called_once_with("INBOX", {})
+
+
+def test_classify_messages_logs_specific_reason_when_runner_up_is_too_close(monkeypatch, caplog):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [104]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class AmbiguousClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict_proba(self, X):
+            return [[0.56, 0.44]]
+
+    ish_instance.classifier = AmbiguousClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={104: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={104: Message(uid=104, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
+
+    with caplog.at_level("DEBUG", logger="ish"):
+        ish_instance.classify_messages(["INBOX"])
+
+    assert "Skipping due to ambiguous top prediction" in caplog.text
+    assert "runner_up=0.44" in caplog.text
+    assert "min_gap=0.15" in caplog.text
+
+
+def test_classify_messages_moves_when_gap_meets_threshold(monkeypatch):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [102]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class ClearEnoughClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict_proba(self, X):
+            return [[0.58, 0.42]]
+
+    ish_instance.classifier = ClearEnoughClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={102: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={102: Message(uid=102, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=1)
+
+    ish_instance.classify_messages(["INBOX"])
+
+    assert ish_instance.skipped == 0
+    ish_instance._classification_service.move_messages.assert_called_once()
+
+
+def test_classify_messages_skips_when_probability_equals_threshold(monkeypatch):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [103]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class ThresholdEdgeClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict_proba(self, X):
+            return [[0.55, 0.45]]
+
+    ish_instance.classifier = ThresholdEdgeClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={103: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={103: Message(uid=103, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
+
+    ish_instance.classify_messages(["INBOX"])
+
+    assert ish_instance.skipped >= 1
+    ish_instance._classification_service.move_messages.assert_called_once_with("INBOX", {})
+
+
+def test_classify_messages_logs_specific_reason_when_probability_too_low(monkeypatch, caplog):
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [105]
+    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
+
+    ish_instance = ISH(dry_run=True)
+
+    class ThresholdEdgeClassifier:
+        classes_ = ["destA", "destB"]
+
+        def predict_proba(self, X):
+            return [[0.55, 0.45]]
+
+    ish_instance.classifier = ThresholdEdgeClassifier()
+    ish_instance.get_embeddings = mock.MagicMock(return_value={105: np.array([0.2])})
+    ish_instance.get_msgs = mock.MagicMock(
+        return_value={105: Message(uid=105, from_addr="", to_addr="", body="", subject="")}
+    )
+    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
+
+    with caplog.at_level("DEBUG", logger="ish"):
+        ish_instance.classify_messages(["INBOX"])
+
+    assert "Skipping due to low confidence" in caplog.text
+    assert "top=0.55" in caplog.text
+    assert "min=0.55" in caplog.text
+
+
+def test_classification_sorts_source_uids_newest_first():
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [1, 3, 2]
+
+    class DummyClassifier:
+        classes_ = ["A", "B"]
+
+        def predict_proba(self, X):
+            return [[0.9, 0.1]]
+
+    service = ClassificationService(
+        imap_conn_provider=lambda: fake_imap,
+        get_embeddings=mock.MagicMock(return_value={}),
+        get_messages=mock.MagicMock(return_value={}),
+        model_file="unused.pkl",
+        max_source_messages=2,
+        interactive=False,
+        dry_run=True,
+        exit_event=Event(),
+    )
+    service.classifier = DummyClassifier()
+
+    service.classify_messages(["INBOX"])
+
+    service._get_embeddings.assert_called_once_with("INBOX", [3, 2])
+
+
+def test_classification_rejects_model_with_mismatched_embedding_profile(tmp_path):
+    model_file = tmp_path / "model.pkl"
+    joblib.dump(
+        make_model_bundle(object(), embedding_profile_for_model("text-embedding-old")),
+        model_file,
+    )
+    fake_imap = mock.MagicMock()
+    service = ClassificationService(
+        imap_conn_provider=lambda: fake_imap,
+        get_embeddings=mock.MagicMock(return_value={}),
+        get_messages=mock.MagicMock(return_value={}),
+        model_file=str(model_file),
+        max_source_messages=10,
+        interactive=False,
+        dry_run=True,
+        exit_event=Event(),
+        embedding_profile=embedding_profile_for_model("text-embedding-new"),
+    )
+
+    assert service.classify_messages(["INBOX"]) == (0, 0)
+    fake_imap.search.assert_not_called()

--- a/tests/test_embedding_store.py
+++ b/tests/test_embedding_store.py
@@ -1,0 +1,125 @@
+from unittest import mock
+
+import numpy as np
+
+from ish.db import LEGACY_EMBEDDING_PROFILE, SQLiteCache
+from ish.embedding_store import (
+    EMBEDDING_INPUT_PROFILE,
+    EmbeddingStore,
+    embedding_profile_for_model,
+)
+from ish.message import Message
+
+
+def test_message_embedding_text_includes_structured_headers():
+    message = Message(
+        uid=1,
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        subject="Travel",
+        body="Boarding pass attached",
+    )
+
+    assert message.embedding_text() == (
+        "From: alice@example.com\n"
+        "To: bob@example.com\n"
+        "Subject: Travel\n"
+        "Body: Boarding pass attached"
+    )
+
+
+def test_embedding_store_ignores_legacy_profile_and_regenerates_active_embedding(tmp_path):
+    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
+    message = Message(
+        uid=1,
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        subject="Travel",
+        body="Boarding pass attached",
+    )
+    msg_hash = cache.store_message("INBOX", 1, message)
+    cache.store_embedding(msg_hash, np.array([1.0]), LEGACY_EMBEDDING_PROFILE)
+
+    repository = mock.MagicMock()
+    repository.get_hashes.return_value = {1: msg_hash}
+    repository.get_messages.return_value = {1: message}
+    embedder = mock.MagicMock(return_value=[np.array([2.0])])
+    store = EmbeddingStore(
+        cache=cache,
+        message_repository=repository,
+        embedder=embedder,
+        max_chars=8192,
+        data_directory=str(tmp_path),
+    )
+
+    embeddings = store.get_embeddings("INBOX", [1])
+
+    assert embeddings[1].tolist() == [2.0]
+    assert cache.get_embedding(msg_hash, LEGACY_EMBEDDING_PROFILE).tolist() == [1.0]
+    assert cache.get_embedding(msg_hash, EMBEDDING_INPUT_PROFILE).tolist() == [2.0]
+    embedder.assert_called_once_with([message.embedding_text()])
+
+
+def test_embedding_store_reuses_active_profile_embedding(tmp_path):
+    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
+    message = Message(
+        uid=1,
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        subject="Travel",
+        body="Boarding pass attached",
+    )
+    msg_hash = cache.store_message("INBOX", 1, message)
+    cache.store_embedding(msg_hash, np.array([3.0]), EMBEDDING_INPUT_PROFILE)
+
+    repository = mock.MagicMock()
+    repository.get_hashes.return_value = {1: msg_hash}
+    embedder = mock.MagicMock()
+    store = EmbeddingStore(
+        cache=cache,
+        message_repository=repository,
+        embedder=embedder,
+        max_chars=8192,
+        data_directory=str(tmp_path),
+    )
+
+    embeddings = store.get_embeddings("INBOX", [1])
+
+    assert embeddings[1].tolist() == [3.0]
+    embedder.assert_not_called()
+    repository.get_messages.assert_not_called()
+
+
+def test_embedding_profile_includes_openai_model_and_model_change_misses_cache(tmp_path):
+    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
+    message = Message(
+        uid=1,
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        subject="Travel",
+        body="Boarding pass attached",
+    )
+    msg_hash = cache.store_message("INBOX", 1, message)
+    old_profile = embedding_profile_for_model("text-embedding-old")
+    new_profile = embedding_profile_for_model("text-embedding-new")
+    cache.store_embedding(msg_hash, np.array([1.0]), old_profile)
+
+    repository = mock.MagicMock()
+    repository.get_hashes.return_value = {1: msg_hash}
+    repository.get_messages.return_value = {1: message}
+    embedder = mock.MagicMock(return_value=[np.array([2.0])])
+    store = EmbeddingStore(
+        cache=cache,
+        message_repository=repository,
+        embedder=embedder,
+        max_chars=8192,
+        data_directory=str(tmp_path),
+        embedding_profile=new_profile,
+    )
+
+    embeddings = store.get_embeddings("INBOX", [1])
+
+    assert embeddings[1].tolist() == [2.0]
+    assert cache.get_embedding(msg_hash, old_profile).tolist() == [1.0]
+    assert cache.get_embedding(msg_hash, new_profile).tolist() == [2.0]
+    embedder.assert_called_once_with([message.embedding_text()])

--- a/tests/test_ish.py
+++ b/tests/test_ish.py
@@ -1,8 +1,4 @@
 import os
-import pickle
-import sqlite3
-import types
-from threading import Event
 from types import SimpleNamespace
 from unittest import mock
 
@@ -11,27 +7,15 @@ import numpy as np
 import pytest
 
 import ish.app as ish_mod
-from ish.db import LEGACY_EMBEDDING_PROFILE, SQLiteCache
-from ish.embedding_store import (
-    EMBEDDING_INPUT_PROFILE,
-    EmbeddingStore,
-    embedding_profile_for_model,
-)
 from ish.app import ISH
-from ish.classification_service import ClassificationService
-from ish.message import Message
-from ish.migrate_shelve_to_sql import _rehash_and_reconcile
+from ish.embedding_store import embedding_profile_for_model
 from ish.model_store import make_model_bundle
-from ish.training_manager import TrainingManager
 
 
 def make_fake_openai_client():
-    """Return a fake OpenAI client where embeddings.create returns an object
-    with .data list of SimpleNamespace(embedding=...)."""
     client = mock.MagicMock()
 
     def create(input, model):
-        # create an embedding object for every input item
         return SimpleNamespace(data=[SimpleNamespace(embedding=np.array([len(i)])) for i in input])
 
     client.embeddings.create = mock.MagicMock(side_effect=create)
@@ -42,7 +26,6 @@ def test___get_embeddings_batches_calls_api_multiple_times():
     ish = ISH(dry_run=True)
     ish._ISH__client = make_fake_openai_client()
 
-    # 25 items -> batch size 20 then 5 -> should call embeddings.create twice
     texts = [f"text-{i}" for i in range(25)]
     embeddings = ish._ISH__get_embeddings(texts)
 
@@ -61,7 +44,7 @@ def test_move_messages_dry_run_does_not_call_imap_move():
     }
 
     moved = ish.move_messages("INBOX", messages)
-    # Dry run should not call IMAP client's move method
+
     mock_conn.move.assert_not_called()
     assert moved == 0
 
@@ -76,206 +59,15 @@ def test_move_messages_calls_imap_move_when_not_dry_run():
     }
 
     moved = ish.move_messages("SRC", messages)
+
     mock_conn.move.assert_called_once_with(
-        "SRC", [10, 11], "X", flag_messages=ish.interactive, flag_unseen=not ish.interactive
+        "SRC",
+        [10, 11],
+        "X",
+        flag_messages=ish.interactive,
+        flag_unseen=not ish.interactive,
     )
     assert moved == 2
-
-
-
-
-def test_classify_messages_moves_high_probability_and_skips_low(monkeypatch):
-    fake_imap = mock.MagicMock()
-    fake_imap.search.return_value = [42]
-    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
-
-    ish_instance = ISH(dry_run=True)
-    # Provide a simple classifier that returns deterministic predictions/probabilities
-    class DummyClassifier:
-        classes_ = ["dest1", "dest2"]
-
-        def predict(self, X):
-            # always predict dest1
-            return ["dest1"]
-
-        def predict_proba(self, X):
-            # single high probability for class 'dest1'
-            return [[0.8, 0.2]]
-
-    test_msg = Message(uid=42, from_addr="alice@example.com", to_addr="bob@example.com", body="Hello world",subject="Test")
-
-    ish_instance.classifier = DummyClassifier()
-    ish_instance.get_embeddings = mock.MagicMock(return_value={42: np.array([0.1, 0.2, 0.3])})
-    ish_instance.get_msgs = mock.MagicMock(return_value={42: test_msg})
-    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=1)
-
-    ish_instance.classify_messages(["INBOX"])
-    ish_instance._classification_service.move_messages.assert_called()
-    assert ish_instance.moved >= 0
-
-
-def test_classify_messages_skips_when_probability_low(monkeypatch):
-    fake_imap = mock.MagicMock()
-    fake_imap.search.return_value = [99]
-    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
-
-    ish_instance = ISH(dry_run=True)
-
-    class LowProbClassifier:
-        classes_ = ["destA", "destB"]
-
-        def predict_proba(self, X):
-            # Top probability stays below the configured minimum.
-            return [[0.52, 0.48]]
-
-    ish_instance.classifier = LowProbClassifier()
-    ish_instance.get_embeddings = mock.MagicMock(return_value={99: np.array([0.1])})
-    ish_instance.get_msgs = mock.MagicMock(return_value={99: Message(uid=99, from_addr="", to_addr="", body="", subject="")})
-    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
-
-    ish_instance.classify_messages(["INBOX"])
-    assert ish_instance.skipped >= 1
-    ish_instance._classification_service.move_messages.assert_called()
-
-
-def test_classify_messages_skips_when_runner_up_is_too_close(monkeypatch):
-    fake_imap = mock.MagicMock()
-    fake_imap.search.return_value = [101]
-    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
-
-    ish_instance = ISH(dry_run=True)
-
-    class AmbiguousClassifier:
-        classes_ = ["destA", "destB"]
-
-        def predict(self, X):
-            return ["destA"]
-
-        def predict_proba(self, X):
-            # Top prediction clears the minimum probability threshold,
-            # but the runner-up is too close to move safely.
-            return [[0.56, 0.44]]
-
-    ish_instance.classifier = AmbiguousClassifier()
-    ish_instance.get_embeddings = mock.MagicMock(return_value={101: np.array([0.2])})
-    ish_instance.get_msgs = mock.MagicMock(
-        return_value={101: Message(uid=101, from_addr="", to_addr="", body="", subject="")}
-    )
-    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
-
-    ish_instance.classify_messages(["INBOX"])
-
-    assert ish_instance.skipped >= 1
-    ish_instance._classification_service.move_messages.assert_called_once_with("INBOX", {})
-
-
-def test_classify_messages_logs_specific_reason_when_runner_up_is_too_close(monkeypatch, caplog):
-    fake_imap = mock.MagicMock()
-    fake_imap.search.return_value = [104]
-    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
-
-    ish_instance = ISH(dry_run=True)
-
-    class AmbiguousClassifier:
-        classes_ = ["destA", "destB"]
-
-        def predict_proba(self, X):
-            return [[0.56, 0.44]]
-
-    ish_instance.classifier = AmbiguousClassifier()
-    ish_instance.get_embeddings = mock.MagicMock(return_value={104: np.array([0.2])})
-    ish_instance.get_msgs = mock.MagicMock(
-        return_value={104: Message(uid=104, from_addr="", to_addr="", body="", subject="")}
-    )
-    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
-
-    with caplog.at_level("DEBUG", logger="ish"):
-        ish_instance.classify_messages(["INBOX"])
-
-    assert "Skipping due to ambiguous top prediction" in caplog.text
-    assert "runner_up=0.44" in caplog.text
-    assert "min_gap=0.15" in caplog.text
-
-
-def test_classify_messages_moves_when_gap_meets_threshold(monkeypatch):
-    fake_imap = mock.MagicMock()
-    fake_imap.search.return_value = [102]
-    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
-
-    ish_instance = ISH(dry_run=True)
-
-    class ClearEnoughClassifier:
-        classes_ = ["destA", "destB"]
-
-        def predict_proba(self, X):
-            # Clears both thresholds with room for float precision.
-            return [[0.58, 0.42]]
-
-    ish_instance.classifier = ClearEnoughClassifier()
-    ish_instance.get_embeddings = mock.MagicMock(return_value={102: np.array([0.2])})
-    ish_instance.get_msgs = mock.MagicMock(
-        return_value={102: Message(uid=102, from_addr="", to_addr="", body="", subject="")}
-    )
-    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=1)
-
-    ish_instance.classify_messages(["INBOX"])
-
-    assert ish_instance.skipped == 0
-    ish_instance._classification_service.move_messages.assert_called_once()
-
-
-def test_classify_messages_skips_when_probability_equals_threshold(monkeypatch):
-    fake_imap = mock.MagicMock()
-    fake_imap.search.return_value = [103]
-    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
-
-    ish_instance = ISH(dry_run=True)
-
-    class ThresholdEdgeClassifier:
-        classes_ = ["destA", "destB"]
-
-        def predict_proba(self, X):
-            return [[0.55, 0.45]]
-
-    ish_instance.classifier = ThresholdEdgeClassifier()
-    ish_instance.get_embeddings = mock.MagicMock(return_value={103: np.array([0.2])})
-    ish_instance.get_msgs = mock.MagicMock(
-        return_value={103: Message(uid=103, from_addr="", to_addr="", body="", subject="")}
-    )
-    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
-
-    ish_instance.classify_messages(["INBOX"])
-
-    assert ish_instance.skipped >= 1
-    ish_instance._classification_service.move_messages.assert_called_once_with("INBOX", {})
-
-
-def test_classify_messages_logs_specific_reason_when_probability_too_low(monkeypatch, caplog):
-    fake_imap = mock.MagicMock()
-    fake_imap.search.return_value = [105]
-    monkeypatch.setattr(ish_mod, "ImapHandler", lambda *a, **k: fake_imap)
-
-    ish_instance = ISH(dry_run=True)
-
-    class ThresholdEdgeClassifier:
-        classes_ = ["destA", "destB"]
-
-        def predict_proba(self, X):
-            return [[0.55, 0.45]]
-
-    ish_instance.classifier = ThresholdEdgeClassifier()
-    ish_instance.get_embeddings = mock.MagicMock(return_value={105: np.array([0.2])})
-    ish_instance.get_msgs = mock.MagicMock(
-        return_value={105: Message(uid=105, from_addr="", to_addr="", body="", subject="")}
-    )
-    ish_instance._classification_service.move_messages = mock.MagicMock(return_value=0)
-
-    with caplog.at_level("DEBUG", logger="ish"):
-        ish_instance.classify_messages(["INBOX"])
-
-    assert "Skipping due to low confidence" in caplog.text
-    assert "top=0.55" in caplog.text
-    assert "min=0.55" in caplog.text
 
 
 def test_ish_reads_thresholds_from_settings(monkeypatch):
@@ -300,20 +92,12 @@ def test_ish_reads_thresholds_from_settings(monkeypatch):
     assert ish_instance._classification_service._runner_up_gap_threshold == pytest.approx(0.21)
 
 
-def make_handler_with_mock_conn():
-    handler = ImapHandler(settings=mock.MagicMock(), readonly=False) # pyright: ignore[reportUndefinedVariable]
-    conn = mock.MagicMock()
-    handler._ImapHandler__imap_conn = conn
-    return handler, conn
-# Use this helper in tests that exercise __search, fetch, list_folders, etc.
-
-
 def test_init_sets_flags_and_dry_run():
     ish = ISH(interactive=True, train=True, daemon=True, dry_run=True)
+
     assert ish.interactive is True
     assert ish.train is True
     assert ish.daemon is True
-    # internal attribute for dry-run exists and was set
     assert getattr(ish, "_dry_run", None) is True
 
 
@@ -358,289 +142,18 @@ def test_run_calls_learn_when_no_model_file(tmp_path, monkeypatch):
     )
     fake_settings.update_data_settings = lambda: None
     monkeypatch.setattr(ish_mod, "Settings", lambda debug=False: fake_settings)
-    
+
     ish = ISH(dry_run=True, train=True)
-    # Ensure training has folders to learn from
-    #ish.__settings["destination_folders"] = ["Important"]
-
     monkeypatch.setattr(os.path, "isfile", lambda path: False)
-
-    # make connect succeed
     monkeypatch.setattr(ish, "connect", lambda: True)
-    # stub classify_messages so run doesn't try to use network
     monkeypatch.setattr(ish, "classify_messages", lambda _: None)
-
-    # replace learn_folders with a mock to confirm it's called
     learn_mock = mock.MagicMock(return_value="trained")
     monkeypatch.setattr(ish, "learn_folders", learn_mock)
 
     rc = ish.run()
+
     assert rc == 0
-    # since no model file existed, learn_folders should have been invoked once
     assert learn_mock.called is True
-
-
-def test_learn_folders_uses_cached_embeddings(monkeypatch, tmp_path):
-    config_dir = tmp_path / "ish_conf"
-    monkeypatch.setenv("ISH_CONFIG_PATH", str(config_dir))
-    monkeypatch.setattr(joblib, "dump", lambda *a, **k: None)
-
-    ish = ISH(dry_run=True)
-    fake_imap = mock.MagicMock()
-    fake_imap.search.side_effect = [[0, 1, 2], [10, 11, 12]]
-    ish._ISH__imap_conn = fake_imap
-    monkeypatch.setattr(ish, "get_embeddings", lambda folder, uids: {})
-
-    folders = ["FolderA", "FolderB"]
-    for folder_idx, folder in enumerate(folders):
-        for sample_idx in range(3):
-            uid = folder_idx * 10 + sample_idx
-            msg = Message(uid=uid, from_addr="a", to_addr="b", subject="s", body=f"body-{folder_idx}-{sample_idx}")
-            msg_hash = ish._cache.store_message(folder, uid, msg)
-            ish._cache.store_embedding(
-                msg_hash,
-                np.array([float(uid), float(sample_idx)]),
-                EMBEDDING_INPUT_PROFILE,
-            )
-
-    clf = ish.learn_folders(folders)
-    assert clf is not None
-
-
-def test_training_ignores_cached_embeddings_for_uids_not_in_folder_search():
-    fake_imap = mock.MagicMock()
-    fake_imap.search.side_effect = [[1, 2], [10, 11]]
-
-    cached = {
-        "FolderA": {
-            1: np.array([1.0]),
-            2: np.array([2.0]),
-            999: np.array([999.0]),
-        },
-        "FolderB": {
-            10: np.array([10.0]),
-            11: np.array([11.0]),
-            998: np.array([998.0]),
-        },
-    }
-
-    manager = TrainingManager(
-        imap_conn_provider=lambda: fake_imap,
-        get_embeddings=lambda folder, uids: {},
-        get_cache_embeddings=lambda folder: dict(cached[folder]),
-        model_file="unused.pkl",
-        max_learn_messages=100,
-        exit_event=Event(),
-        embedding_profile=EMBEDDING_INPUT_PROFILE,
-    )
-
-    embeddings, labels = manager._collect_training_data(fake_imap, ["FolderA", "FolderB"])
-
-    assert len(embeddings) == 4
-    assert labels == ["FolderA", "FolderA", "FolderB", "FolderB"]
-    assert all(float(emb[0]) not in {998.0, 999.0} for emb in embeddings)
-
-
-def test_message_embedding_text_includes_structured_headers():
-    message = Message(
-        uid=1,
-        from_addr="alice@example.com",
-        to_addr="bob@example.com",
-        subject="Travel",
-        body="Boarding pass attached",
-    )
-
-    assert message.embedding_text() == (
-        "From: alice@example.com\n"
-        "To: bob@example.com\n"
-        "Subject: Travel\n"
-        "Body: Boarding pass attached"
-    )
-
-
-def test_classification_sorts_source_uids_newest_first():
-    fake_imap = mock.MagicMock()
-    fake_imap.search.return_value = [1, 3, 2]
-
-    class DummyClassifier:
-        classes_ = ["A", "B"]
-
-        def predict_proba(self, X):
-            return [[0.9, 0.1]]
-
-    service = ClassificationService(
-        imap_conn_provider=lambda: fake_imap,
-        get_embeddings=mock.MagicMock(return_value={}),
-        get_messages=mock.MagicMock(return_value={}),
-        model_file="unused.pkl",
-        max_source_messages=2,
-        interactive=False,
-        dry_run=True,
-        exit_event=Event(),
-    )
-    service.classifier = DummyClassifier()
-
-    service.classify_messages(["INBOX"])
-
-    service._get_embeddings.assert_called_once_with("INBOX", [3, 2])
-
-
-def test_embedding_store_ignores_legacy_profile_and_regenerates_active_embedding(tmp_path):
-    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
-    message = Message(
-        uid=1,
-        from_addr="alice@example.com",
-        to_addr="bob@example.com",
-        subject="Travel",
-        body="Boarding pass attached",
-    )
-    msg_hash = cache.store_message("INBOX", 1, message)
-    cache.store_embedding(msg_hash, np.array([1.0]), LEGACY_EMBEDDING_PROFILE)
-
-    repository = mock.MagicMock()
-    repository.get_hashes.return_value = {1: msg_hash}
-    repository.get_messages.return_value = {1: message}
-    embedder = mock.MagicMock(return_value=[np.array([2.0])])
-    store = EmbeddingStore(
-        cache=cache,
-        message_repository=repository,
-        embedder=embedder,
-        max_chars=8192,
-        data_directory=str(tmp_path),
-    )
-
-    embeddings = store.get_embeddings("INBOX", [1])
-
-    assert embeddings[1].tolist() == [2.0]
-    assert cache.get_embedding(msg_hash, LEGACY_EMBEDDING_PROFILE).tolist() == [1.0]
-    assert cache.get_embedding(msg_hash, EMBEDDING_INPUT_PROFILE).tolist() == [2.0]
-    embedder.assert_called_once_with([message.embedding_text()])
-
-
-def test_embedding_store_reuses_active_profile_embedding(tmp_path):
-    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
-    message = Message(
-        uid=1,
-        from_addr="alice@example.com",
-        to_addr="bob@example.com",
-        subject="Travel",
-        body="Boarding pass attached",
-    )
-    msg_hash = cache.store_message("INBOX", 1, message)
-    cache.store_embedding(msg_hash, np.array([3.0]), EMBEDDING_INPUT_PROFILE)
-
-    repository = mock.MagicMock()
-    repository.get_hashes.return_value = {1: msg_hash}
-    embedder = mock.MagicMock()
-    store = EmbeddingStore(
-        cache=cache,
-        message_repository=repository,
-        embedder=embedder,
-        max_chars=8192,
-        data_directory=str(tmp_path),
-    )
-
-    embeddings = store.get_embeddings("INBOX", [1])
-
-    assert embeddings[1].tolist() == [3.0]
-    embedder.assert_not_called()
-    repository.get_messages.assert_not_called()
-
-
-def test_embedding_profile_includes_openai_model_and_model_change_misses_cache(tmp_path):
-    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
-    message = Message(
-        uid=1,
-        from_addr="alice@example.com",
-        to_addr="bob@example.com",
-        subject="Travel",
-        body="Boarding pass attached",
-    )
-    msg_hash = cache.store_message("INBOX", 1, message)
-    old_profile = embedding_profile_for_model("text-embedding-old")
-    new_profile = embedding_profile_for_model("text-embedding-new")
-    cache.store_embedding(msg_hash, np.array([1.0]), old_profile)
-
-    repository = mock.MagicMock()
-    repository.get_hashes.return_value = {1: msg_hash}
-    repository.get_messages.return_value = {1: message}
-    embedder = mock.MagicMock(return_value=[np.array([2.0])])
-    store = EmbeddingStore(
-        cache=cache,
-        message_repository=repository,
-        embedder=embedder,
-        max_chars=8192,
-        data_directory=str(tmp_path),
-        embedding_profile=new_profile,
-    )
-
-    embeddings = store.get_embeddings("INBOX", [1])
-
-    assert embeddings[1].tolist() == [2.0]
-    assert cache.get_embedding(msg_hash, old_profile).tolist() == [1.0]
-    assert cache.get_embedding(msg_hash, new_profile).tolist() == [2.0]
-    embedder.assert_called_once_with([message.embedding_text()])
-
-
-def test_training_saves_classifier_with_embedding_profile_metadata(monkeypatch):
-    profile = embedding_profile_for_model("text-embedding-3-small")
-    classifier = object()
-    dump_mock = mock.MagicMock()
-    monkeypatch.setattr(joblib, "dump", dump_mock)
-
-    manager = TrainingManager(
-        imap_conn_provider=lambda: mock.MagicMock(),
-        get_embeddings=lambda folder, uids: {},
-        get_cache_embeddings=lambda folder: {},
-        model_file="model.pkl",
-        max_learn_messages=100,
-        exit_event=Event(),
-        embedding_profile=profile,
-    )
-    monkeypatch.setattr(
-        manager,
-        "_collect_training_data",
-        lambda imap_conn, folders: (
-            [np.array([1.0]), np.array([2.0]), np.array([3.0]), np.array([4.0])],
-            ["A", "A", "B", "B"],
-        ),
-    )
-    monkeypatch.setattr(
-        manager,
-        "_split_training_data",
-        lambda X, y: (X[:2], X[2:], y[:2], y[2:]),
-    )
-    monkeypatch.setattr(manager, "_train_classifier", lambda X_train, y_train: classifier)
-    monkeypatch.setattr(manager, "_evaluate_classifier", lambda clf, X_test, y_test, folders: 0.5)
-
-    assert manager.learn_folders(["A", "B"]) is classifier
-    payload, model_file = dump_mock.call_args.args
-
-    assert model_file == "model.pkl"
-    assert payload == make_model_bundle(classifier, profile)
-
-
-def test_classification_rejects_model_with_mismatched_embedding_profile(tmp_path):
-    model_file = tmp_path / "model.pkl"
-    joblib.dump(
-        make_model_bundle(object(), embedding_profile_for_model("text-embedding-old")),
-        model_file,
-    )
-    fake_imap = mock.MagicMock()
-    service = ClassificationService(
-        imap_conn_provider=lambda: fake_imap,
-        get_embeddings=mock.MagicMock(return_value={}),
-        get_messages=mock.MagicMock(return_value={}),
-        model_file=str(model_file),
-        max_source_messages=10,
-        interactive=False,
-        dry_run=True,
-        exit_event=Event(),
-        embedding_profile=embedding_profile_for_model("text-embedding-new"),
-    )
-
-    assert service.classify_messages(["INBOX"]) == (0, 0)
-    fake_imap.search.assert_not_called()
 
 
 def test_run_retrains_when_existing_model_has_mismatched_embedding_profile(tmp_path, monkeypatch):
@@ -671,108 +184,3 @@ def test_run_retrains_when_existing_model_has_mismatched_embedding_profile(tmp_p
 
     assert ish.run() == 0
     train_mock.assert_called_once_with()
-
-
-def test_sqlite_cache_migrates_legacy_embedding_schema_with_profile_and_timestamps(tmp_path):
-    db_path = tmp_path / "cache.sqlite"
-    conn = sqlite3.connect(db_path)
-    conn.executescript(
-        """
-        CREATE TABLE messages_content (
-            msg_hash TEXT PRIMARY KEY,
-            from_addr TEXT,
-            to_addr TEXT,
-            subject TEXT,
-            body TEXT
-        );
-        CREATE TABLE folder_messages (
-            folder TEXT,
-            uid INTEGER,
-            msg_hash TEXT,
-            PRIMARY KEY (folder, uid),
-            FOREIGN KEY (msg_hash) REFERENCES messages_content(msg_hash) ON DELETE CASCADE
-        );
-        CREATE TABLE embeddings (
-            msg_hash TEXT PRIMARY KEY,
-            data BLOB,
-            FOREIGN KEY (msg_hash) REFERENCES messages_content(msg_hash) ON DELETE CASCADE
-        );
-        """
-    )
-    message = Message(uid=1, from_addr="a", to_addr="b", subject="s", body="body")
-    msg_hash = message.hash()
-    conn.execute(
-        "INSERT INTO messages_content (msg_hash, from_addr, to_addr, subject, body) VALUES (?, ?, ?, ?, ?)",
-        (msg_hash, message.from_addr, message.to_addr, message.subject, message.body),
-    )
-    conn.execute(
-        "INSERT INTO embeddings (msg_hash, data) VALUES (?, ?)",
-        (msg_hash, sqlite3.Binary(pickle.dumps(np.array([1.0])))),
-    )
-    conn.commit()
-    conn.close()
-
-    cache = SQLiteCache(str(db_path))
-    cur = cache.conn.cursor()
-    cur.execute("PRAGMA table_info(embeddings)")
-    columns = {row[1] for row in cur.fetchall()}
-    cur.execute("SELECT profile, created_at, updated_at FROM embeddings WHERE msg_hash = ?", (msg_hash,))
-    profile, created_at, updated_at = cur.fetchone()
-
-    assert {"msg_hash", "profile", "data", "created_at", "updated_at"}.issubset(columns)
-    assert profile == LEGACY_EMBEDDING_PROFILE
-    assert created_at
-    assert updated_at
-    assert cache.get_embedding(msg_hash, EMBEDDING_INPUT_PROFILE) is None
-    assert cache.get_embedding(msg_hash, LEGACY_EMBEDDING_PROFILE).tolist() == [1.0]
-
-
-def test_rehash_preserves_embedding_profile_and_timestamps(tmp_path):
-    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
-    conn = cache.conn
-    message = Message(uid=1, from_addr="a", to_addr="b", subject="s", body="body")
-    old_hash = "legacy-hash"
-    computed_hash = message.hash()
-    created_at = "2024-01-01T00:00:00+00:00"
-    updated_at = "2024-02-01T00:00:00+00:00"
-
-    conn.execute(
-        "INSERT INTO messages_content (msg_hash, from_addr, to_addr, subject, body) VALUES (?, ?, ?, ?, ?)",
-        (old_hash, message.from_addr, message.to_addr, message.subject, message.body),
-    )
-    conn.execute(
-        "INSERT INTO folder_messages (folder, uid, msg_hash) VALUES (?, ?, ?)",
-        ("INBOX", 1, old_hash),
-    )
-    conn.execute(
-        """
-        INSERT INTO embeddings (msg_hash, profile, data, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?)
-        """,
-        (
-            old_hash,
-            LEGACY_EMBEDDING_PROFILE,
-            sqlite3.Binary(pickle.dumps(np.array([1.0]))),
-            created_at,
-            updated_at,
-        ),
-    )
-    conn.commit()
-
-    assert _rehash_and_reconcile(conn) == {"updated": 1, "merged": 0, "skipped": 0}
-
-    cur = conn.cursor()
-    cur.execute("SELECT msg_hash FROM folder_messages WHERE folder = ? AND uid = ?", ("INBOX", 1))
-    assert cur.fetchone()[0] == computed_hash
-    cur.execute(
-        "SELECT profile, data, created_at, updated_at FROM embeddings WHERE msg_hash = ?",
-        (computed_hash,),
-    )
-    profile, data, stored_created_at, stored_updated_at = cur.fetchone()
-
-    assert profile == LEGACY_EMBEDDING_PROFILE
-    assert pickle.loads(data).tolist() == [1.0]
-    assert stored_created_at == created_at
-    assert stored_updated_at == updated_at
-    cur.execute("SELECT 1 FROM messages_content WHERE msg_hash = ?", (old_hash,))
-    assert cur.fetchone() is None

--- a/tests/test_ish.py
+++ b/tests/test_ish.py
@@ -1,4 +1,6 @@
 import os
+import pickle
+import sqlite3
 import types
 from threading import Event
 from types import SimpleNamespace
@@ -9,6 +11,8 @@ import numpy as np
 import pytest
 
 import ish.app as ish_mod
+from ish.db import LEGACY_EMBEDDING_PROFILE, SQLiteCache
+from ish.embedding_store import EMBEDDING_INPUT_PROFILE, EmbeddingStore
 from ish.app import ISH
 from ish.classification_service import ClassificationService
 from ish.message import Message
@@ -387,7 +391,11 @@ def test_learn_folders_uses_cached_embeddings(monkeypatch, tmp_path):
             uid = folder_idx * 10 + sample_idx
             msg = Message(uid=uid, from_addr="a", to_addr="b", subject="s", body=f"body-{folder_idx}-{sample_idx}")
             msg_hash = ish._cache.store_message(folder, uid, msg)
-            ish._cache.store_embedding(msg_hash, np.array([float(uid), float(sample_idx)]))
+            ish._cache.store_embedding(
+                msg_hash,
+                np.array([float(uid), float(sample_idx)]),
+                EMBEDDING_INPUT_PROFILE,
+            )
 
     clf = ish.learn_folders(folders)
     assert clf is not None
@@ -468,3 +476,119 @@ def test_classification_sorts_source_uids_newest_first():
     service.classify_messages(["INBOX"])
 
     service._get_embeddings.assert_called_once_with("INBOX", [3, 2])
+
+
+def test_embedding_store_ignores_legacy_profile_and_regenerates_active_embedding(tmp_path):
+    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
+    message = Message(
+        uid=1,
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        subject="Travel",
+        body="Boarding pass attached",
+    )
+    msg_hash = cache.store_message("INBOX", 1, message)
+    cache.store_embedding(msg_hash, np.array([1.0]), LEGACY_EMBEDDING_PROFILE)
+
+    repository = mock.MagicMock()
+    repository.get_hashes.return_value = {1: msg_hash}
+    repository.get_messages.return_value = {1: message}
+    embedder = mock.MagicMock(return_value=[np.array([2.0])])
+    store = EmbeddingStore(
+        cache=cache,
+        message_repository=repository,
+        embedder=embedder,
+        max_chars=8192,
+        data_directory=str(tmp_path),
+    )
+
+    embeddings = store.get_embeddings("INBOX", [1])
+
+    assert embeddings[1].tolist() == [2.0]
+    assert cache.get_embedding(msg_hash, LEGACY_EMBEDDING_PROFILE).tolist() == [1.0]
+    assert cache.get_embedding(msg_hash, EMBEDDING_INPUT_PROFILE).tolist() == [2.0]
+    embedder.assert_called_once_with([message.embedding_text()])
+
+
+def test_embedding_store_reuses_active_profile_embedding(tmp_path):
+    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
+    message = Message(
+        uid=1,
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        subject="Travel",
+        body="Boarding pass attached",
+    )
+    msg_hash = cache.store_message("INBOX", 1, message)
+    cache.store_embedding(msg_hash, np.array([3.0]), EMBEDDING_INPUT_PROFILE)
+
+    repository = mock.MagicMock()
+    repository.get_hashes.return_value = {1: msg_hash}
+    embedder = mock.MagicMock()
+    store = EmbeddingStore(
+        cache=cache,
+        message_repository=repository,
+        embedder=embedder,
+        max_chars=8192,
+        data_directory=str(tmp_path),
+    )
+
+    embeddings = store.get_embeddings("INBOX", [1])
+
+    assert embeddings[1].tolist() == [3.0]
+    embedder.assert_not_called()
+    repository.get_messages.assert_not_called()
+
+
+def test_sqlite_cache_migrates_legacy_embedding_schema_with_profile_and_timestamps(tmp_path):
+    db_path = tmp_path / "cache.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE messages_content (
+            msg_hash TEXT PRIMARY KEY,
+            from_addr TEXT,
+            to_addr TEXT,
+            subject TEXT,
+            body TEXT
+        );
+        CREATE TABLE folder_messages (
+            folder TEXT,
+            uid INTEGER,
+            msg_hash TEXT,
+            PRIMARY KEY (folder, uid),
+            FOREIGN KEY (msg_hash) REFERENCES messages_content(msg_hash) ON DELETE CASCADE
+        );
+        CREATE TABLE embeddings (
+            msg_hash TEXT PRIMARY KEY,
+            data BLOB,
+            FOREIGN KEY (msg_hash) REFERENCES messages_content(msg_hash) ON DELETE CASCADE
+        );
+        """
+    )
+    message = Message(uid=1, from_addr="a", to_addr="b", subject="s", body="body")
+    msg_hash = message.hash()
+    conn.execute(
+        "INSERT INTO messages_content (msg_hash, from_addr, to_addr, subject, body) VALUES (?, ?, ?, ?, ?)",
+        (msg_hash, message.from_addr, message.to_addr, message.subject, message.body),
+    )
+    conn.execute(
+        "INSERT INTO embeddings (msg_hash, data) VALUES (?, ?)",
+        (msg_hash, sqlite3.Binary(pickle.dumps(np.array([1.0])))),
+    )
+    conn.commit()
+    conn.close()
+
+    cache = SQLiteCache(str(db_path))
+    cur = cache.conn.cursor()
+    cur.execute("PRAGMA table_info(embeddings)")
+    columns = {row[1] for row in cur.fetchall()}
+    cur.execute("SELECT profile, created_at, updated_at FROM embeddings WHERE msg_hash = ?", (msg_hash,))
+    profile, created_at, updated_at = cur.fetchone()
+
+    assert {"msg_hash", "profile", "data", "created_at", "updated_at"}.issubset(columns)
+    assert profile == LEGACY_EMBEDDING_PROFILE
+    assert created_at
+    assert updated_at
+    assert cache.get_embedding(msg_hash, EMBEDDING_INPUT_PROFILE) is None
+    assert cache.get_embedding(msg_hash, LEGACY_EMBEDDING_PROFILE).tolist() == [1.0]

--- a/tests/test_ish.py
+++ b/tests/test_ish.py
@@ -12,10 +12,16 @@ import pytest
 
 import ish.app as ish_mod
 from ish.db import LEGACY_EMBEDDING_PROFILE, SQLiteCache
-from ish.embedding_store import EMBEDDING_INPUT_PROFILE, EmbeddingStore
+from ish.embedding_store import (
+    EMBEDDING_INPUT_PROFILE,
+    EmbeddingStore,
+    embedding_profile_for_model,
+)
 from ish.app import ISH
 from ish.classification_service import ClassificationService
 from ish.message import Message
+from ish.migrate_shelve_to_sql import _rehash_and_reconcile
+from ish.model_store import make_model_bundle
 from ish.training_manager import TrainingManager
 
 
@@ -425,6 +431,7 @@ def test_training_ignores_cached_embeddings_for_uids_not_in_folder_search():
         model_file="unused.pkl",
         max_learn_messages=100,
         exit_event=Event(),
+        embedding_profile=EMBEDDING_INPUT_PROFILE,
     )
 
     embeddings, labels = manager._collect_training_data(fake_imap, ["FolderA", "FolderB"])
@@ -540,6 +547,132 @@ def test_embedding_store_reuses_active_profile_embedding(tmp_path):
     repository.get_messages.assert_not_called()
 
 
+def test_embedding_profile_includes_openai_model_and_model_change_misses_cache(tmp_path):
+    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
+    message = Message(
+        uid=1,
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        subject="Travel",
+        body="Boarding pass attached",
+    )
+    msg_hash = cache.store_message("INBOX", 1, message)
+    old_profile = embedding_profile_for_model("text-embedding-old")
+    new_profile = embedding_profile_for_model("text-embedding-new")
+    cache.store_embedding(msg_hash, np.array([1.0]), old_profile)
+
+    repository = mock.MagicMock()
+    repository.get_hashes.return_value = {1: msg_hash}
+    repository.get_messages.return_value = {1: message}
+    embedder = mock.MagicMock(return_value=[np.array([2.0])])
+    store = EmbeddingStore(
+        cache=cache,
+        message_repository=repository,
+        embedder=embedder,
+        max_chars=8192,
+        data_directory=str(tmp_path),
+        embedding_profile=new_profile,
+    )
+
+    embeddings = store.get_embeddings("INBOX", [1])
+
+    assert embeddings[1].tolist() == [2.0]
+    assert cache.get_embedding(msg_hash, old_profile).tolist() == [1.0]
+    assert cache.get_embedding(msg_hash, new_profile).tolist() == [2.0]
+    embedder.assert_called_once_with([message.embedding_text()])
+
+
+def test_training_saves_classifier_with_embedding_profile_metadata(monkeypatch):
+    profile = embedding_profile_for_model("text-embedding-3-small")
+    classifier = object()
+    dump_mock = mock.MagicMock()
+    monkeypatch.setattr(joblib, "dump", dump_mock)
+
+    manager = TrainingManager(
+        imap_conn_provider=lambda: mock.MagicMock(),
+        get_embeddings=lambda folder, uids: {},
+        get_cache_embeddings=lambda folder: {},
+        model_file="model.pkl",
+        max_learn_messages=100,
+        exit_event=Event(),
+        embedding_profile=profile,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_collect_training_data",
+        lambda imap_conn, folders: (
+            [np.array([1.0]), np.array([2.0]), np.array([3.0]), np.array([4.0])],
+            ["A", "A", "B", "B"],
+        ),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_split_training_data",
+        lambda X, y: (X[:2], X[2:], y[:2], y[2:]),
+    )
+    monkeypatch.setattr(manager, "_train_classifier", lambda X_train, y_train: classifier)
+    monkeypatch.setattr(manager, "_evaluate_classifier", lambda clf, X_test, y_test, folders: 0.5)
+
+    assert manager.learn_folders(["A", "B"]) is classifier
+    payload, model_file = dump_mock.call_args.args
+
+    assert model_file == "model.pkl"
+    assert payload == make_model_bundle(classifier, profile)
+
+
+def test_classification_rejects_model_with_mismatched_embedding_profile(tmp_path):
+    model_file = tmp_path / "model.pkl"
+    joblib.dump(
+        make_model_bundle(object(), embedding_profile_for_model("text-embedding-old")),
+        model_file,
+    )
+    fake_imap = mock.MagicMock()
+    service = ClassificationService(
+        imap_conn_provider=lambda: fake_imap,
+        get_embeddings=mock.MagicMock(return_value={}),
+        get_messages=mock.MagicMock(return_value={}),
+        model_file=str(model_file),
+        max_source_messages=10,
+        interactive=False,
+        dry_run=True,
+        exit_event=Event(),
+        embedding_profile=embedding_profile_for_model("text-embedding-new"),
+    )
+
+    assert service.classify_messages(["INBOX"]) == (0, 0)
+    fake_imap.search.assert_not_called()
+
+
+def test_run_retrains_when_existing_model_has_mismatched_embedding_profile(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    fake_settings = SimpleNamespace(
+        data_directory=str(data_dir),
+        source_folders=["INBOX"],
+        destination_folders=["Important"],
+        ignore_folders=[],
+        openai_api_key="key",
+        openai_model="text-embedding-new",
+        classification_probability_threshold=0.55,
+        classification_runner_up_gap_threshold=0.15,
+    )
+    fake_settings.update_data_settings = lambda: None
+    monkeypatch.setattr(ish_mod, "Settings", lambda debug=False: fake_settings)
+
+    ish = ISH(dry_run=True)
+    joblib.dump(
+        make_model_bundle(object(), embedding_profile_for_model("text-embedding-old")),
+        ish.model_file,
+    )
+    monkeypatch.setattr(ish, "connect", lambda: True)
+    train_mock = mock.MagicMock(return_value=True)
+    monkeypatch.setattr(ish, "train_on_destination_folders", train_mock)
+    monkeypatch.setattr(ish, "classify_messages", lambda source_folders: None)
+
+    assert ish.run() == 0
+    train_mock.assert_called_once_with()
+
+
 def test_sqlite_cache_migrates_legacy_embedding_schema_with_profile_and_timestamps(tmp_path):
     db_path = tmp_path / "cache.sqlite"
     conn = sqlite3.connect(db_path)
@@ -592,3 +725,54 @@ def test_sqlite_cache_migrates_legacy_embedding_schema_with_profile_and_timestam
     assert updated_at
     assert cache.get_embedding(msg_hash, EMBEDDING_INPUT_PROFILE) is None
     assert cache.get_embedding(msg_hash, LEGACY_EMBEDDING_PROFILE).tolist() == [1.0]
+
+
+def test_rehash_preserves_embedding_profile_and_timestamps(tmp_path):
+    cache = SQLiteCache(str(tmp_path / "cache.sqlite"))
+    conn = cache.conn
+    message = Message(uid=1, from_addr="a", to_addr="b", subject="s", body="body")
+    old_hash = "legacy-hash"
+    computed_hash = message.hash()
+    created_at = "2024-01-01T00:00:00+00:00"
+    updated_at = "2024-02-01T00:00:00+00:00"
+
+    conn.execute(
+        "INSERT INTO messages_content (msg_hash, from_addr, to_addr, subject, body) VALUES (?, ?, ?, ?, ?)",
+        (old_hash, message.from_addr, message.to_addr, message.subject, message.body),
+    )
+    conn.execute(
+        "INSERT INTO folder_messages (folder, uid, msg_hash) VALUES (?, ?, ?)",
+        ("INBOX", 1, old_hash),
+    )
+    conn.execute(
+        """
+        INSERT INTO embeddings (msg_hash, profile, data, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            old_hash,
+            LEGACY_EMBEDDING_PROFILE,
+            sqlite3.Binary(pickle.dumps(np.array([1.0]))),
+            created_at,
+            updated_at,
+        ),
+    )
+    conn.commit()
+
+    assert _rehash_and_reconcile(conn) == {"updated": 1, "merged": 0, "skipped": 0}
+
+    cur = conn.cursor()
+    cur.execute("SELECT msg_hash FROM folder_messages WHERE folder = ? AND uid = ?", ("INBOX", 1))
+    assert cur.fetchone()[0] == computed_hash
+    cur.execute(
+        "SELECT profile, data, created_at, updated_at FROM embeddings WHERE msg_hash = ?",
+        (computed_hash,),
+    )
+    profile, data, stored_created_at, stored_updated_at = cur.fetchone()
+
+    assert profile == LEGACY_EMBEDDING_PROFILE
+    assert pickle.loads(data).tolist() == [1.0]
+    assert stored_created_at == created_at
+    assert stored_updated_at == updated_at
+    cur.execute("SELECT 1 FROM messages_content WHERE msg_hash = ?", (old_hash,))
+    assert cur.fetchone() is None

--- a/tests/test_ish.py
+++ b/tests/test_ish.py
@@ -1,5 +1,6 @@
 import os
 import types
+from threading import Event
 from types import SimpleNamespace
 from unittest import mock
 
@@ -9,7 +10,9 @@ import pytest
 
 import ish.app as ish_mod
 from ish.app import ISH
+from ish.classification_service import ClassificationService
 from ish.message import Message
+from ish.training_manager import TrainingManager
 
 
 def make_fake_openai_client():
@@ -374,7 +377,7 @@ def test_learn_folders_uses_cached_embeddings(monkeypatch, tmp_path):
 
     ish = ISH(dry_run=True)
     fake_imap = mock.MagicMock()
-    fake_imap.search.return_value = []
+    fake_imap.search.side_effect = [[0, 1, 2], [10, 11, 12]]
     ish._ISH__imap_conn = fake_imap
     monkeypatch.setattr(ish, "get_embeddings", lambda folder, uids: {})
 
@@ -388,3 +391,80 @@ def test_learn_folders_uses_cached_embeddings(monkeypatch, tmp_path):
 
     clf = ish.learn_folders(folders)
     assert clf is not None
+
+
+def test_training_ignores_cached_embeddings_for_uids_not_in_folder_search():
+    fake_imap = mock.MagicMock()
+    fake_imap.search.side_effect = [[1, 2], [10, 11]]
+
+    cached = {
+        "FolderA": {
+            1: np.array([1.0]),
+            2: np.array([2.0]),
+            999: np.array([999.0]),
+        },
+        "FolderB": {
+            10: np.array([10.0]),
+            11: np.array([11.0]),
+            998: np.array([998.0]),
+        },
+    }
+
+    manager = TrainingManager(
+        imap_conn_provider=lambda: fake_imap,
+        get_embeddings=lambda folder, uids: {},
+        get_cache_embeddings=lambda folder: dict(cached[folder]),
+        model_file="unused.pkl",
+        max_learn_messages=100,
+        exit_event=Event(),
+    )
+
+    embeddings, labels = manager._collect_training_data(fake_imap, ["FolderA", "FolderB"])
+
+    assert len(embeddings) == 4
+    assert labels == ["FolderA", "FolderA", "FolderB", "FolderB"]
+    assert all(float(emb[0]) not in {998.0, 999.0} for emb in embeddings)
+
+
+def test_message_embedding_text_includes_structured_headers():
+    message = Message(
+        uid=1,
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        subject="Travel",
+        body="Boarding pass attached",
+    )
+
+    assert message.embedding_text() == (
+        "From: alice@example.com\n"
+        "To: bob@example.com\n"
+        "Subject: Travel\n"
+        "Body: Boarding pass attached"
+    )
+
+
+def test_classification_sorts_source_uids_newest_first():
+    fake_imap = mock.MagicMock()
+    fake_imap.search.return_value = [1, 3, 2]
+
+    class DummyClassifier:
+        classes_ = ["A", "B"]
+
+        def predict_proba(self, X):
+            return [[0.9, 0.1]]
+
+    service = ClassificationService(
+        imap_conn_provider=lambda: fake_imap,
+        get_embeddings=mock.MagicMock(return_value={}),
+        get_messages=mock.MagicMock(return_value={}),
+        model_file="unused.pkl",
+        max_source_messages=2,
+        interactive=False,
+        dry_run=True,
+        exit_event=Event(),
+    )
+    service.classifier = DummyClassifier()
+
+    service.classify_messages(["INBOX"])
+
+    service._get_embeddings.assert_called_once_with("INBOX", [3, 2])

--- a/tests/test_training_manager.py
+++ b/tests/test_training_manager.py
@@ -1,0 +1,110 @@
+from threading import Event
+from unittest import mock
+
+import joblib
+import numpy as np
+
+from ish.app import ISH
+from ish.embedding_store import EMBEDDING_INPUT_PROFILE, embedding_profile_for_model
+from ish.message import Message
+from ish.model_store import make_model_bundle
+from ish.training_manager import TrainingManager
+
+
+def test_learn_folders_uses_cached_embeddings(monkeypatch, tmp_path):
+    config_dir = tmp_path / "ish_conf"
+    monkeypatch.setenv("ISH_CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(joblib, "dump", lambda *a, **k: None)
+
+    ish = ISH(dry_run=True)
+    fake_imap = mock.MagicMock()
+    fake_imap.search.side_effect = [[0, 1, 2], [10, 11, 12]]
+    ish._ISH__imap_conn = fake_imap
+    monkeypatch.setattr(ish, "get_embeddings", lambda folder, uids: {})
+
+    folders = ["FolderA", "FolderB"]
+    for folder_idx, folder in enumerate(folders):
+        for sample_idx in range(3):
+            uid = folder_idx * 10 + sample_idx
+            msg = Message(uid=uid, from_addr="a", to_addr="b", subject="s", body=f"body-{folder_idx}-{sample_idx}")
+            msg_hash = ish._cache.store_message(folder, uid, msg)
+            ish._cache.store_embedding(
+                msg_hash,
+                np.array([float(uid), float(sample_idx)]),
+                EMBEDDING_INPUT_PROFILE,
+            )
+
+    clf = ish.learn_folders(folders)
+    assert clf is not None
+
+
+def test_training_ignores_cached_embeddings_for_uids_not_in_folder_search():
+    fake_imap = mock.MagicMock()
+    fake_imap.search.side_effect = [[1, 2], [10, 11]]
+
+    cached = {
+        "FolderA": {
+            1: np.array([1.0]),
+            2: np.array([2.0]),
+            999: np.array([999.0]),
+        },
+        "FolderB": {
+            10: np.array([10.0]),
+            11: np.array([11.0]),
+            998: np.array([998.0]),
+        },
+    }
+
+    manager = TrainingManager(
+        imap_conn_provider=lambda: fake_imap,
+        get_embeddings=lambda folder, uids: {},
+        get_cache_embeddings=lambda folder: dict(cached[folder]),
+        model_file="unused.pkl",
+        max_learn_messages=100,
+        exit_event=Event(),
+        embedding_profile=EMBEDDING_INPUT_PROFILE,
+    )
+
+    embeddings, labels = manager._collect_training_data(fake_imap, ["FolderA", "FolderB"])
+
+    assert len(embeddings) == 4
+    assert labels == ["FolderA", "FolderA", "FolderB", "FolderB"]
+    assert all(float(emb[0]) not in {998.0, 999.0} for emb in embeddings)
+
+
+def test_training_saves_classifier_with_embedding_profile_metadata(monkeypatch):
+    profile = embedding_profile_for_model("text-embedding-3-small")
+    classifier = object()
+    dump_mock = mock.MagicMock()
+    monkeypatch.setattr(joblib, "dump", dump_mock)
+
+    manager = TrainingManager(
+        imap_conn_provider=lambda: mock.MagicMock(),
+        get_embeddings=lambda folder, uids: {},
+        get_cache_embeddings=lambda folder: {},
+        model_file="model.pkl",
+        max_learn_messages=100,
+        exit_event=Event(),
+        embedding_profile=profile,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_collect_training_data",
+        lambda imap_conn, folders: (
+            [np.array([1.0]), np.array([2.0]), np.array([3.0]), np.array([4.0])],
+            ["A", "A", "B", "B"],
+        ),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_split_training_data",
+        lambda X, y: (X[:2], X[2:], y[:2], y[2:]),
+    )
+    monkeypatch.setattr(manager, "_train_classifier", lambda X_train, y_train: classifier)
+    monkeypatch.setattr(manager, "_evaluate_classifier", lambda clf, X_test, y_test, folders: 0.5)
+
+    assert manager.learn_folders(["A", "B"]) is classifier
+    payload, model_file = dump_mock.call_args.args
+
+    assert model_file == "model.pkl"
+    assert payload == make_model_bundle(classifier, profile)


### PR DESCRIPTION
## Summary

- Improve training sample quality by filtering cached folder embeddings to UIDs still present in the current IMAP folder search.
- Use structured message text for embeddings, including sender, recipient, subject, and body.
- Version embedding cache entries by input profile and OpenAI embedding model so legacy vectors remain stored but are not silently reused for the new profile.
- Store classifier metadata with the embedding profile and retrain when an existing model is incompatible.
- Improve classifier training with stratified validation when safe, class balancing, calibrated probabilities when data allows, and newest-first source UID processing.
- Split the large test module into cohesive test files and add VS Code/pytest configuration for reliable discovery.

## Why

The prior cache/model behavior could mix vectors generated from different embedding inputs or models, and it could reuse stale cached labels during training. That created silent precision/recall risk, especially for users with existing cache.sqlite/model.pkl data.

## Validation

- `.venv/bin/python -m pytest tests`
- Result: `53 passed`

## Notes

- Legacy embeddings are preserved under the `legacy-body-v1` profile.
- Active embeddings use a profile derived from the structured input format and configured OpenAI embedding model.
- Interactive mode behavior was intentionally left unchanged.